### PR TITLE
Fix all build warnings, remove reflink requirement

### DIFF
--- a/about/introduction.rst
+++ b/about/introduction.rst
@@ -13,7 +13,7 @@ After Canonical suddenly announced `their plans to terminate support of Ubuntu T
 About the Documentation
 -----------------------
 
-This documentation is always improving thanks to the members of the UBports community. It is written in ReStructuredText and converted into this readable form by `Sphinx <http://www.sphinx-doc.org/en/stable/>`_, `ReCommonMark <http://recommonmark.readthedocs.io/en/latest/>`_, and `Read the Docs <https://readthedocs.io>`_. You can start contributing by checking out the :ref:`Documentation intro <contribute-doc-index>`.
+This documentation is always improving thanks to the members of the UBports community. It is written in ReStructuredText and converted into this readable form by `Sphinx <http://www.sphinx-doc.org/en/stable/>`_, `ReCommonMark <http://recommonmark.readthedocs.io/en/latest/>`_, and `Read the Docs <https://readthedocs.io>`_. You can start contributing by checking out the :doc:`Documentation intro </contribute/documentation>`.
 
 All documents are licensed under the Creative Commons Attribution ShareAlike 4.0 (`CC-BY-SA 4.0 <https://creativecommons.org/licenses/by-sa/4.0/>`_) license. Please give attribution to "The UBports Community".
 

--- a/appdev/clickable/cordova.rst
+++ b/appdev/clickable/cordova.rst
@@ -1,63 +1,56 @@
 Using clickable for cordova and HTML-5 development
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==================================================
 
 About the guide
 ---------------
 
-The purpose of the page is to provide a guide similar to :doc:`this one <clickable>`_ for developing Cordova-based (and maybe other HTML5-based) applications using LXC container. Such applications are built in chroot environment, and build system is for some time unsupported in Xenial. I don't know if there are still any developers who use Cordova for Ubuntu, but if there are some, I hope the guide will be useful.
+The purpose of the page is to provide a guide similar to :doc:`this one <setup>` for developing Cordova-based (and maybe other HTML5-based) applications using LXC container. Such applications are built in chroot environment, and build system is for some time unsupported in Xenial. I don't know if there are still any developers who use Cordova for Ubuntu, but if there are some, I hope the guide will be useful.
 
 The steps needed to setup working environment are basicly the same as in original guide with few modifications specific to build environment.
 
-1. | Set up LXD The steps to set up LXD are the same as in `original
-     post :doc:<clickable>`__.
-   | We also need to enable **overlay** kernel module (it is required by
-     *click* command to function properly):
-   | ``sudo modprobe overlay``
+1. Set up LXD as detailed in in :doc:`the original setup post <setup>`. We also need to enable **overlay** kernel module (it is required by *click* command to function properly)::
 
-2. | Set up the container We need 17.04+ container, because fixes for
-     build system are published only there and not in 16.04.
-   | ``lxc launch ubuntu:17.04 clickablecontainer      lxc config set clickablecontainer security.privileged true      lxc config set clickablecontainer security.nesting true      lxc restart clickablecontainer      lxc exec clickablecontainer -- /bin/bash``
+    sudo modprobe overlay
 
-3. | Inside the container Inside the container we have to do basically
-     the same three things: basic configuration of the system, creation
-     of a new not root user and configuring *clickable*. Steps to create
-     basic configuration of the system and a new not root user are the
-     same as in original post:
-   | \`\`\`
-   | apt update
-   | apt install nano sudo git
-   | adduser mr\_nice\_guy usermod -a -G sudo mr\_nice\_guy
+2. We need a 17.04+ container, because fixes for build system are published only there and not in 16.04::
 
-| # Now we are ready to being the nice guy
-| su mr\_nice\_guy
-| \`\`\`
+    lxc launch ubuntu:17.04 clickablecontainer
+    lxc config set clickablecontainer security.privileged true
+    lxc config set clickablecontainer security.nesting true
+    lxc restart clickablecontainer
+    lxc exec clickablecontainer -- /bin/bash
+  
+3. Inside the container Inside the container we have to do basically the same three things: basic configuration of the system, creation of a new not root user and configuring *clickable*. Steps to create basic configuration of the system and a new not root user are the same as in original post::
+
+    apt update
+    apt install nano sudo git
+    adduser mr_nice_guy usermod -a -G sudo mr_nice_guy
+    su mr_nice_guy
 
 4. Configure Clickable
 
--  Download *clickable* and add it to ``PATH``.
--  Install NodeJS:
-   ``sudo -S apt install nodejs-legacy npm``
--  Install build tools
-   ``sudo -S apt install click-dev phablet-tools``
--  Download and Install *cordova-cli* package from Cordova PPA (the PPA
-   is only for Xenial, so I downloaded it manually):
-   ``wget https://launchpad.net/~cordova-ubuntu/+archive/ubuntu/ppa/+build/9778583/+files/cordova-cli_4.3.1-ubuntu12_all.deb;      sudo -S dpkg -i cordova-cli_4.3.1-ubuntu12_all.deb``
--  Create chroot environment for building apps:
-   ``sudo -S click chroot -a armhf -f ubuntu-sdk-15.04 create``
-   That's it. We now should have a working clickable environment for
-   building Cordova apps.
+  1. Download *clickable* and add it to your ``PATH``.
 
-5. Notes on Cordova usage
-   There are number of unfixed long-standing issues with Cordova for
-   Ubuntu. So if you'd like to create apps using Cordova, you might be
-   interested in `project's
-   fork <https://github.com/milikhin/cordova-ubuntu>`__. It is based on
-   last official version, but adds few fixes that make it more usable:
+  2. Install NodeJS, build tools, and the cordova-cli package from the Cordova PPA::
 
--  WebView is automatically resized when on-screen keyboard is
-   shown/hidden
--  Copy/Paste operations are supported with touchscreen
+      sudo -S apt install nodejs-legacy npm
+      sudo -S apt install click-dev phablet-tools
+      wget https://launchpad.net/~cordova-ubuntu/+archive/ubuntu/ppa/+build/9778583/+files/cordova-cli_4.3.1-ubuntu12_all.deb
+      sudo -S dpkg -i cordova-cli_4.3.1-ubuntu12_all.deb
 
-There is also repository with patched `File
-plugin <https://github.com/milikhin/cordova-plugin-file>`__, which gives
-applications ability to list hidden files and directories.
+  3. Create chroot environment for building apps::
+
+      sudo -S click chroot -a armhf -f ubuntu-sdk-15.04 create
+   
+That's it. We now should have a working clickable environment for
+building Cordova apps.
+
+Notes on Cordova usage
+~~~~~~~~~~~~~~~~~~~~~~
+
+There are number of unfixed long-standing issues with Cordova for Ubuntu. So if you'd like to create apps using Cordova, you might be interested in `project's fork <https://github.com/milikhin/cordova-ubuntu>`_. It is based on last official version, but adds few fixes that make it more usable:
+
+*  WebView is automatically resized when on-screen keyboard is shown/hidden
+*  Copy/Paste operations are supported with touchscreen
+
+There is also repository with patched `File plugin <https://github.com/milikhin/cordova-plugin-file>`__, which gives applications ability to list hidden files and directories.

--- a/appdev/clickable/inside-lxd.rst
+++ b/appdev/clickable/inside-lxd.rst
@@ -1,4 +1,3 @@
-.. _clickable-inside-lxd:
 Set up an lxd container for clickable
 =====================================
 

--- a/appdev/clickable/setup.rst
+++ b/appdev/clickable/setup.rst
@@ -2,7 +2,7 @@ Setting up clickable
 ====================
 
 This guide assumes you are using Ubuntu 16.04 on your development
-machine. Other host systems might work just fine as well. If you cannot set up Clickable as described here you might want to try the alternative instructions to setup clickable :ref:`inside an LXD container <clickable-inside-lxd>`, or check out the `Clickable website <https://github.com/bhdouglass/clickable>`__ for further alternatives like snap.
+machine. Other host systems might work just fine as well. If you cannot set up Clickable as described here you might want to try the alternative instructions to setup clickable :doc:`inside an LXD container <inside-lxd>`, or check out the `Clickable website <https://github.com/bhdouglass/clickable>`__ for further alternatives like snap.
 
 Prerequisites
 -------------

--- a/appdev/on-device/lazarus.rst
+++ b/appdev/on-device/lazarus.rst
@@ -1,14 +1,14 @@
 Right before diving into the topic, please consider checking the page
 about [[UT on-device software development]].
 
-|LazarusIDE on Ubuntu Phone| |LazarusIDE on Ubuntu Phone|
+|LazarusIDE on Ubuntu Phone 1| |LazarusIDE on Ubuntu Phone 2|
 
 Introduction
 ------------
 
-`Lazarus IDE <https://www.lazarus-ide.org>`__ is a cross-platform open
+`Lazarus IDE <https://www.lazarus-ide.org>`_ is a cross-platform open
 source and free IDE based on Delphi, that also supports ARM Linux
-natively. It uses `Free Pascal compiler <https://www.freepascal.org>`__,
+natively. It uses `Free Pascal compiler <https://www.freepascal.org>`_,
 and you can use it to compile once written code to a plethora of
 targets, including (but not limited to): Windows, OSX, Linux, and
 plethora of architectures, including Intel, ARM and many others. Both
@@ -16,21 +16,22 @@ Free Pascal compiler and Lazarus IDE can be compiled, or installed from
 precompiled binaries/packages on Ubuntu Touch, using a default ARM Linux
 releases. In fact both **fpc** and **lazarus** packages are available in
 the default Ubuntu repositories, but most likely these are not the most
-recent versions, so on your Ubuntu Touch you could just run:
-
-::
+recent versions, so on your Ubuntu Touch you could just run::
 
     sudo apt-get install fpc lazarus
      
 
-Just that in reality there are few problems with this: \* on UT devices
+Just that in reality there are few problems with this: 
+* on UT devices
 by default the system partition is read-only (can be easilyremounted to
-rw though) \* on UT devices by default the free space on system
+rw though) 
+* on UT devices by default the free space on system
 partition is quite low and might not be enough for installing both
 packages along with all dependencies (on Meizu MX4 phone with original
 UT only fpc package was possible to install, but not lazarus due to
 insufficient space). The resizing of the filesystem is not a very easy
-task. \* by default Lazarus IDE, which is a GTK app starts in
+task. 
+* by default Lazarus IDE, which is a GTK app starts in
 multi-window mode, which does not work well when running gtk on the UT
 device via XMir. Lazarus can be configured into single window mode (see
 screenshots on top of this page), which solves the problem.
@@ -157,6 +158,6 @@ fact, you can do that even on Windows host. whatever you create and
 compile inside such a chroot environment, you can just copy over to your
 UT device, because it will be a valid ARM Linux binary.
 
-.. |LazarusIDE on Ubuntu Phone| image:: https://qph.ec.quoracdn.net/main-qimg-4ac8c75b2f4d0ac80fc82d74a48b1bd3
-.. |LazarusIDE on Ubuntu Phone| image:: https://qph.ec.quoracdn.net/main-qimg-60417c6805535103beb6b0f5e63ac290
+.. |LazarusIDE on Ubuntu Phone 1| image:: https://qph.ec.quoracdn.net/main-qimg-4ac8c75b2f4d0ac80fc82d74a48b1bd3
+.. |LazarusIDE on Ubuntu Phone 2| image:: https://qph.ec.quoracdn.net/main-qimg-60417c6805535103beb6b0f5e63ac290
 

--- a/conf.py
+++ b/conf.py
@@ -107,7 +107,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/contribute/bugreporting.rst
+++ b/contribute/bugreporting.rst
@@ -1,4 +1,3 @@
-.. _contribute-bugreporting-index:
 Bug reporting
 =============
 
@@ -28,7 +27,7 @@ Getting Logs
 
 We appreciate as many good logs as we can get when you report a bug. In general, /var/log/dmesg and the output of /android/system/bin/logcat are helpful when resolving an issue. I'll show you how to get these logs.
 
-To get set ready, follow the steps to :ref:`set up ADB<userguide-advanceduse-adb>`.
+To get set ready, follow the steps to :doc:`set up ADB </userguide/advanceduse/adb>`.
 
 Now, you can get the two most important logs.
 

--- a/contribute/documentation.rst
+++ b/contribute/documentation.rst
@@ -31,25 +31,6 @@ Titles should be sentence cased rather than Title Cased. For example::
 
 There isn't a single definition of title casing that everyone follows, but sentence casing is easy. This helps keep capitalization in the table of contents consistent.
 
-Reference
-^^^^^^^^^
-
-References create a permanent link. One should always appear as the first line of your document.
-
-For example, take a look at this document's first three lines::
-
-    .. _contribute-doc-index:
-    Documentation
-    =============
-
-The reference name can be called in another document to easily link to a page::
-
-    For example, check out the :ref:`Documentation intro <contribute-doc-index>`
-
-This will create a link to this page that won't change if this page changes directories in a reorganization later.
-
-Your reference should follow the naming scheme ``part-section-title``. This document, for example, is the index of the Documentation (doc) section in the Contribute part of the documentation.
-
 Table of contents
 ^^^^^^^^^^^^^^^^^
 

--- a/contribute/documentation.rst
+++ b/contribute/documentation.rst
@@ -1,4 +1,3 @@
-.. _contribute-doc-index:
 Documentation
 =============
 

--- a/contribute/index.rst
+++ b/contribute/index.rst
@@ -1,10 +1,9 @@
-.. _contribute-index:
 Contributing to UBports
 =======================
 
 Welcome! You're probably here because you want to contribute to UBports. The pages you'll find below here will help you do this in a way that's helpful to both the project and yourself.
 
-If you're just getting started, we always need help with :ref:`thorough bug reporting <contribute-bugreporting-index>`. If you are multilingual, :ref:`translations <contribute-translations-index>` are also a great place to start.
+If you're just getting started, we always need help with :doc:`thorough bug reporting <bugreporting>`. If you are multilingual, :doc:`translations <translations>` are also a great place to start.
 
 If those aren't enough for you, see `our contribute page <https://ubports.com/page/vo-get-involved>`_ for an introduction of our focus groups.
 

--- a/contribute/issuetracking.rst
+++ b/contribute/issuetracking.rst
@@ -32,73 +32,48 @@ To increase transparency and communication, GitHub projects
 ubports/ubuntu-touch, a seperate project is used for every team (HAL,
 Middleware, User Interface)
 
-+----------------+---------------------------------------------------------------------------+
-| Column         | Description                                                               |
-+================+===========================================================================+
-|----------------|---------------------------------------------------------------------------|
-| *None          | The issue has been approved by the issue manager and is awaiting review   |
-| ("awaiting     | from the responsible team. If the issue is a bug, instructions to re-     |
-| triage")*      | produce are included in the issue description. If the issue is a feature- |
-|                | request, it has passed a primary sanity check by the issue manager, but   |
-|                | has not yet been accepted by the team.                                    |
-|----------------|---------------------------------------------------------------------------|
-| Accepted       | The issue has been accepted by the responsible team. If the issue is a    |
-|                | bugreport, the team has decided that it should be fixable and accepts the |
-|                | responsibility. If the issue is a featrue request, the team thinks it     |
-|                | should be implemented as described.                                       |
-|----------------|---------------------------------------------------------------------------|
-| In Development | A patch is in development. Usually, a developer is assigned to the issue. |
-|----------------|---------------------------------------------------------------------------|
-| Quality        | The patch is completed and has passed initial testing. The QA team will   |
-| Assurance      | now review it on all devices and provide feedback. If problems are found, |
-|                | the issue is moved back to "In Development".                              |
-|----------------|---------------------------------------------------------------------------|
-| Release        | The patch has passed QA and is ready for release. In case of deb-packages |
-| Candidate      | that are included in the system-image, the patch will be included in the  |
-|                | next over-the-air update on the rc channel, and, if everything goes well, |
-|                | in the next release of the stable channel.                                |
-|----------------|---------------------------------------------------------------------------|
-| *Removed from  | A patch has been released (issue closed with a message linking to the     |
-| the project*   | patch), the issue has been rejected (issue closed labeled "rejected"), or |
-|                | the issue was moved to a different responsible team.                      |
-+----------------+---------------------------------------------------------------------------+
+* **None (awaiting triage)**: The issue has been approved by the issue manager and is awaiting review from the responsible team. if the issue is a bug, instructions to reproduce are included in the issue description. if the issue is a feature request, it has passed a primary sanity check by the issue manager but has not yet been accepted by the team.
+* **Accepted**: The issue has been accepted by the responsible team. If the issue is a bugreport, the team has decided that it should be fixable and accepts the responsibility. If the issue is a featrue request, the team thinks it should be implemented as described.
+* **In Development**: A patch is in development. Usually means that a developer is assigned to the issue.
+* **Quality Assurance**: The patch is completed and has passed initial testing. The QA team will now review it on all devices and provide feedback. If problems are found, the issue is moved back to “In Development”.
+* **Release Candidate**: The patch has passed QA and is ready for release. In case of deb-packages that are included in the system-image, the patch will be included in the next over-the-air update on the rc channel, and, if everything goes well, in the next release of the stable channel.
+* **Removed from the project**: A patch has been released (issue closed with a message linking to the patch), the issue has been rejected (issue closed labeled “rejected”), or the issue was moved to a different responsible team.
 
 Labels
 ------
 
 Issues (even closed ones) should be labeled to allow the use of GitHub's
-global filtering. Example:
-https://github.com/search?utf8=%E2%9C%93&q=is%3Aopen+org%3Aubports+label%3A%22feature+request%22&type=
+global filtering. For example, `these are all of the issues labeled 'feature request' inside @ubports <https://github.com/search?utf8=%E2%9C%93&q=is%3Aopen+org%3Aubports+label%3A%22feature+request%22&type=>`_.
 
 Here's a list of general trackers that are used by all repositories.
 
--  needs confirmation: The bug needs confirmation and / or further
+-  **needs confirmation**: The bug needs confirmation and / or further
    information from affected users
--  bug: This issue is a confirmed bug. If it's reproducable,
+-  **bug**: This issue is a confirmed bug. If it's reproducable,
    reproduction steps are described.
--  opinion: This issue needs further discussion.
--  feature request: This issue is a feature request.
--  question: This issue is a support request or general question.
--  invalid: This issue can not be confirmed or was reported in the wrong
+-  **opinion**: This issue needs further discussion.
+-  **feature request**: This issue is a feature request.
+-  **question**: This issue is a support request or general question.
+-  **invalid**: This issue can not be confirmed or was reported in the wrong
    tracker.
--  duplicate: This has already been reported somewhere else. Please
+-  **duplicate**: This has already been reported somewhere else. Please
    provide a link and close.
--  help wanted: This issue is ready to be picked up by a community
+-  **help wanted**: This issue is ready to be picked up by a community
    developer.
--  rejected: It does not make sense to fix this bug, since it will
+-  **rejected**: It does not make sense to fix this bug, since it will
    probably resolve itself, it will be too much work to fix it, it's not
-   fixable or an underlying component will soon change.
+   fixable, or an underlying component will soon change.
 
 Additional special labels can be defined. As an example, here's the
 labels on ubports/ubuntu-touch
 
--  rc-blocker: This is a critical issue blocking the release of the next
+-  **rc-blocker**: This is a critical issue blocking the release of the next
    rc image that is limited to the devel-channel.
--  stable-blocker: This is a critical issue blocking the release of the
+-  **stable-blocker**: This is a critical issue blocking the release of the
    next stable OTA release. Usually, issues that can not simply be moved
    to a different release and therefore must be fixed asap are labeled
    this.
--  device: [DEVICE CODENAME]: This issue affects only the specified
+-  **device: [DEVICE CODENAME]**: This issue affects only the specified
    device(s).
 
 Milestones
@@ -118,8 +93,7 @@ Assignees
 
 To make it transparent who's working on an issue, the developer should
 be assigned. This also allows the use of GitHub's global filtering as a
-type of TODO list:
-https://github.com/search?utf8=%E2%9C%93&q=is%3Aopen+org%3Aubports+assignee%3Amariogrip&type=
+type of TODO list. For example, `this is everything assigned to mariogrip in @ubports <https://github.com/search?utf8=%E2%9C%93&q=is%3Aopen+org%3Aubports+assignee%3Amariogrip&type=>`_.
 
 It's the developers duty to keep his list short and update the status of
 his issues.

--- a/contribute/issuetracking.rst
+++ b/contribute/issuetracking.rst
@@ -1,9 +1,8 @@
-.. _contribute-issues-index:
 Issue Tracking Guidelines
 =========================
 
 This document describes the standard process of dealing with new issues
-in UBports projects. For the guide on writing a good bugreport, visit :ref:`click here <contribute-bugreporting-index>`.
+in UBports projects. For the guide on writing a good bugreport, visit :doc:`click here <documentation>`.
 
 .. note::
     Practicality beats purity! Exceptions might apply and should be described in

--- a/contribute/monetary.rst
+++ b/contribute/monetary.rst
@@ -1,4 +1,3 @@
-.. _contribute-doc-index:
 Monetary support
 ================
 

--- a/contribute/translations.rst
+++ b/contribute/translations.rst
@@ -1,4 +1,3 @@
-.. _contribute-translations-index:
 Translations
 ============
 

--- a/userguide/advanceduse/adb.rst
+++ b/userguide/advanceduse/adb.rst
@@ -1,4 +1,3 @@
-.. _userguide-advanceduse-adb:
 Shell access via adb
 ====================
 

--- a/userguide/advanceduse/index.rst
+++ b/userguide/advanceduse/index.rst
@@ -1,4 +1,3 @@
-.. userguide-advanceduse-index:
 Advanced use
 ============
 

--- a/userguide/advanceduse/ssh.rst
+++ b/userguide/advanceduse/ssh.rst
@@ -1,4 +1,3 @@
-.. _userguide-advanceduse-ssh:
 Shell access via ssh
 ====================
 

--- a/userguide/advanceduse/ssh.rst
+++ b/userguide/advanceduse/ssh.rst
@@ -13,7 +13,7 @@ First you need to transfer your public key to your device. There are multiple wa
 
 * Connect the ubports device and the PC with a USB cable. Then copy the file using your filemanager.
 * Or transfer the key via the internet by mailing it to yourself, or uploading it to your own cloud storage, or webserver, etc. 
-* You can also connect via :ref:`adb<userguide-advanceduse-adb>` and use the following command to copy it::
+* You can also connect via :doc:`adb <adb>` and use the following command to copy it::
 
     adb push ~/.ssh/id_rsa.pub /home/phablet/
 

--- a/userguide/advanceduse/switchchannel.rst
+++ b/userguide/advanceduse/switchchannel.rst
@@ -1,3 +1,2 @@
-.. _userguide-advanceduse-switchchannel:
 Switch release channels
 =======================

--- a/userguide/dailyuse/index.rst
+++ b/userguide/dailyuse/index.rst
@@ -1,4 +1,3 @@
-.. userguide-dailyuse-index:
 Daily use
 =========
 

--- a/userguide/dailyuse/libertine.rst
+++ b/userguide/dailyuse/libertine.rst
@@ -1,4 +1,3 @@
-.. _userguide-dailyuse-libertine:
 Run desktop applications
 ========================
 


### PR DESCRIPTION
This pull request has about 32 fixed warnings (they were bugging me) and removes the requirement for reflinks at the top of every page. Just in time, too, since even I wasn't following them...