### PR TITLE
Add Travis config and disallow warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
 
 install: 
-  - pip install requirements.txt
+  - pip install -r requirements.txt
 
 script:
   - sphinx-build -Wa . _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+
+python:
+  - "2.7"
+
+install: 
+  - pip install requirements.txt
+
+script:
+  - sphinx-build -Wa . _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ install:
 
 script:
   - sphinx-build -Wa . _build
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,3 @@ install:
 
 script:
   - sphinx-build -Wa . _build
-  

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = Ubportsdocs
 SOURCEDIR     = .

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 ## UBports Documentation Website
-This is the repository for the UBports documentation website served at [docs.ubports.com](https://docs.ubports.com). You can find ways to contribute [here](https://docs.ubports.com/en/latest/contribute/documentation.html).
+
+This is the repository for the UBports documentation website served at [docs.ubports.com](https://docs.ubports.com). 
+
+### Contributing to this documentation
+
+You can find ways to contribute [here](https://docs.ubports.com/en/latest/contribute/documentation.html).
+
+### Build instructions
+
+This documentation can be built by doing the following:
+
+Create and activate a Python virtualenv 
+
+```
+virtualenv ~/ubportsdocsenv
+. ~/ubportsdocsenv/bin/activate
+```
+
+Install the Read the Docs theme and ReCommonMark (for Markdown parsing):
+
+```
+pip install sphinx sphinx_rtd_theme recommonmark
+```
+
+Change into the ``docs.ubports.com`` directory:
+
+```
+cd path/to/docs.ubports.com
+```
+
+Build the documentation::
+
+```
+sphinx-build -Wa . _build
+```

--- a/contribute/documentation.rst
+++ b/contribute/documentation.rst
@@ -77,23 +77,28 @@ Building this documentation locally
 If you'd like to build this documentation *before* sending a PR (which you should), follow these instructions on your *local copy* of your fork of the repository.
 
 .. Note::
-    You must have pip installed before following these instructions. On Ubuntu, install the pip package by running ``sudo apt install python-pip``. `This page <https://pip.pypa.io/en/stable/installing/>`_ has instructions for installing Pip on other operating systems and distros.
+    You must have pip and virtualenv installed before following these instructions. On Ubuntu, install the pip package by running ``sudo apt install python-pip``. Then, install virtualenv by running ``sudo pip install virtualenv`` `This page <https://pip.pypa.io/en/stable/installing/>`_ has instructions for installing Pip on other operating systems and distros.
 
-1. Install the Read the Docs theme and ReCommonMark (for Markdown parsing)::
+1. Create a virtualenv for your build environment, and activate it. This will ensure that the dependencies you install do not cause problems with any other Python software on your computer, and is generally regarded as a best practice::
+
+    virtualenv ~/ubportsdocsenv
+    . ~/ubportsdocsenv/bin/activate
+
+2. Install the Read the Docs theme and ReCommonMark (for Markdown parsing)::
 
     pip install sphinx sphinx_rtd_theme recommonmark
 
-2. Change into the ``docs.ubports.com`` directory::
+3. Change into the ``docs.ubports.com`` directory::
 
     cd path/to/docs.ubports.com
 
-3. Build the documentation::
+4. Build the documentation::
 
-    python -m sphinx . _build
+    sphinx-build -Wa . _build
 
-This tells Sphinx to build the documentation found in the current directory, and put it all into ``_build``. There will be a couple of warnings about README.md and a nonexistent static path. Watch out for warnings about anything else, though, they could mean something has gone wrong.
+This tells Sphinx to build the documentation found in the current directory, and put it all into ``_build``. If any warnings occur, the build will fail.
 
-If all went well, you can enter the ``_build`` directory and double-click on ``index.html`` to view the UBports documentation.
+If all went well, you can enter the ``_build`` directory and open ``index.html`` to view the UBports documentation.
 
 Current TODOs
 -------------

--- a/contribute/documentation.rst
+++ b/contribute/documentation.rst
@@ -82,7 +82,7 @@ Building this documentation locally
 If you'd like to build this documentation *before* sending a PR (which you should), follow these instructions on your *local copy* of your fork of the repository.
 
 .. Note::
-    You must have pip and virtualenv installed before following these instructions. On Ubuntu, install the pip package by running ``sudo apt install python-pip``. Then, install virtualenv by running ``sudo pip install virtualenv`` `This page <https://pip.pypa.io/en/stable/installing/>`_ has instructions for installing Pip on other operating systems and distros.
+    You must have pip and virtualenv installed before following these instructions. On Ubuntu, install the pip package by running ``sudo apt install python-pip``. Then, install virtualenv by running ``sudo pip install virtualenv``. `This page <https://pip.pypa.io/en/stable/installing/>`_ has instructions for installing Pip on other operating systems and distros.
 
 1. Create a virtualenv for your build environment, and activate it. This will ensure that the dependencies you install do not cause problems with any other Python software on your computer, and is generally regarded as a best practice::
 

--- a/contribute/documentation.rst
+++ b/contribute/documentation.rst
@@ -47,6 +47,11 @@ You can do this by adding the page to the ``index.rst`` file in the same directo
 
 The order matters. If you would like your page to appear in a certain place in the table of contents, place it there. In the previous example, newpage would be added to the end of this table of contents.
 
+Warnings
+^^^^^^^^
+
+Your edits must not introduce any warnings into the documentation build. If any warnings occur, the build will fail and your pull request will be marked with a red 'X'. Please ensure that your RST is valid and correct before you create a pull request. This is done automatically (via sphinx-build crashing with your error) if you follow our build instructions below.
+
 Contribution workflow
 ---------------------
 
@@ -96,7 +101,9 @@ If you'd like to build this documentation *before* sending a PR (which you shoul
 
     sphinx-build -Wa . _build
 
-This tells Sphinx to build the documentation found in the current directory, and put it all into ``_build``. If any warnings occur, the build will fail.
+This tells Sphinx to build the documentation found in the current directory, and put it all into ``_build``. If any warnings occur, the build will fail. To keep the build from failing so you can find and fix all warnings at once, remove the uppercase W from the command. 
+
+To speed up the build, you may optionally specifiy a ``-jX`` argument at the end of sphinx-build, where X is the number of CPU threads your system has.
 
 If all went well, you can enter the ``_build`` directory and open ``index.html`` to view the UBports documentation.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx_rtd_theme
+recommonmark


### PR DESCRIPTION
Warnings bug me. A lot. I feel that if someone went through the trouble of advising you not to do something while writing a compiler or interpreter, you should listen. Allowing warnings into our documentation 'Just one time' means that we end up with 33 of them very quickly, then we have to go over and fix them in a huge batch. :(

Maybe I'm just a perfectionist.

This PR adds configuration for Travis-CI, which will attempt to build the documentation and treat warnings as errors. It also changes build instructions to advise people to use the `-W` flag and makes a new guideline for warnings. For a cherry on top, I put some build instructions in the README.