### PR TITLE
Update clickable setup instructions

### DIFF
--- a/appdev/clickable/setup.rst
+++ b/appdev/clickable/setup.rst
@@ -1,35 +1,22 @@
 Setting up clickable
 ====================
 
-This guide assumes you are using Ubuntu 16.04 or newer on your development
-machine. Other host systems might work just fine as well. If you cannot set up Clickable as described here you might want to try the alternative instructions to setup clickable :doc:`inside an LXD container <inside-lxd>`, or check out the `Clickable website <https://github.com/bhdouglass/clickable>`__ for further alternatives like snap or deb packages.
+`Clickable <https://github.com/bhdouglass/clickable>`__ is a meta-build system for Ubuntu Touch applications that allows you to compile and build click packages in a docker container. Setting up clickable is simple and makes app development fast and easy!
 
 Prerequisites
 -------------
 
-Ubuntu 16.04 or newer.
-
 ::
 
-    sudo apt-get install lxd android-tools-adb python
-    sudo lxd init
+    sudo apt-get install android-tools-adb python docker.io
+    sudo usermod -a -G docker $USER
 
-You will have to reboot for all changes to take effect.
-
-If you have the Ubuntu SDK IDE installed, you will already have the necessary prerequisites. If you don't already have the IDE installed you will need to install adb and lxd. After installing lxd you will need to run ``lxd init`` to get everything setup with lxd.
-
-.. topic:: Troubleshooting
-
-    If you get an error when running the ``lxd`` command, check if your user is in the lxd group. If you are not in the lxd group you can add yourself like this:
-
-    ``sudo usermod -a -G lxd username``
-
-    You might have to log out and log back in afterwards for this to take effect.
-
-    Another common issue could be to not have the lxd daemon running; if so just run: ``sudo systemctl start lxd.service``
+You might have to reboot for all changes to take effect.
 
 Install
 -------
+
+Installing from the git repository will work for all modern GNU/Linux distributions.
 
 ::
 
@@ -39,21 +26,27 @@ Install
     source ~/.bashrc
     clickable setup-lxd
 
+On Ubuntu 16.04 you can also install clickable from a ppa instead:
+
+::
+
+    sudo add-apt-repository ppa:bhdouglass/clickable
+    sudo apt-get update
+    sudo apt-get install clickable
+
 First app
 ---------
 
-Now you are set up to build and run your first app:
+Now you are set up to build your first app! Activate the developer mode on your device and connect it to your PC to run your app directly on the device:
 
 ::
 
     git clone https://github.com/bhdouglass/ut-app-template
     cd ut-app-template/
-    clickable
+    clickable --docker
 
 This should build and start an app on your Ubuntu Touch device
 displaying "Hello World!"
 
 Look `here <https://github.com/bhdouglass/clickable#usage>`__ for
 further instructions.
-
-        


### PR DESCRIPTION
The lxd method is no longer supported, so i modified the instructions to describe the much simpler docker way to do things. This might just be the best thing since sliced bread.