### PR TITLE
Update ssh.rst

### DIFF
--- a/userguide/advanceduse/ssh.rst
+++ b/userguide/advanceduse/ssh.rst
@@ -42,6 +42,10 @@ Now start the ssh server::
 To make sure the ssh server is automatically started in the future, execute::
 
     sudo setprop persist.service.ssh true
+    
+In case the ssh was not enabled before, use the following command to permit ssh connexion form outside the mobile device::
+
+    android-gadget-tools ssh enable
 
 Connect
 -------


### PR DESCRIPTION
In my experience the default behaviour is that ssh is not enabled at all, so that I usually execute that command to enable its connection. A similar command workes (android-gadget-tools mtp enable) when I can reach the mobile device with MTP, but it was not contextual in this page