### PR TITLE
Fix log commands

### DIFF
--- a/contribute/bugreporting.rst
+++ b/contribute/bugreporting.rst
@@ -40,7 +40,7 @@ The **dmesg** (*display message* or *driver message*) command displays debug mes
 
 #. Using the steps you documented earlier, reproduce the issue you're reporting
 #. cd to a folder where you're able to write the log
-#. Run the command: `adb shell "dmesg" > "UTdmesg.txt"`
+#. Run the command: `adb shell dmesg > UTdmesg.txt`
 
 This log should now be located at UTdmesg.txt under your working directory, ready for uploading later.
 
@@ -50,7 +50,7 @@ logcat
 The **logcat** (*log concatenator*) command displays debug information from various parts of the underlying android system.
 
 #. cd to a folder where you're able to write the log
-#. Run the command: `adb shell /android/system/bin/logcat -d > "UTlogcat.txt"`
+#. Run the command: `adb shell /android/system/bin/logcat -d > UTlogcat.txt`
 #. Using the steps you documented earlier, reproduce the issue you're reporting
 
 This log will be located at UTlogcat.txt in your current working directory, so you'll be able to upload it later.


### PR DESCRIPTION
`adb shell "dmesg"` leads to command not found. The quotes arround the file names become part of it. Thus I removed them.