### PR TITLE
Small porting update

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,8 +19,8 @@ else
   virtualenv ~/ubportsdocsenv
   . ~/ubportsdocsenv/bin/activate
   echo -e "${YELLOW}Installing build tools and prerequisites.${PLAIN}"
-  sudo -H pip install sphinx sphinx_rtd_theme
+  sudo -H pip install sphinx sphinx_rtd_theme sphinx-intl
 fi
 echo -e "${GREEN}Building...${PLAIN}"
-sphinx-build -Wa . _build -j `nproc --all`
+sphinx-build -Wa . _build/html -j `nproc --all`
 exit $?

--- a/porting/building-ubports-boot.rst
+++ b/porting/building-ubports-boot.rst
@@ -10,10 +10,6 @@ Add source to Halium tree
 
 The first thing that needs to be done is adding the ubports-boot source to your Halium tree. You may choose to do this by adding it to your local manifests (recommended) or simply cloning it in place.
 
-.. warning::
-
-    Due to a `bug in the ubports-boot build scripts <https://github.com/ubports/ubports-boot/issues/3>`_, you will need to remove it from your tree before you're able to build ``hybris-boot`` again.
-
 
 Add to local manifest
 ^^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +29,7 @@ Now, just do a ``repo sync`` to download the new source.
 Manual clone
 ^^^^^^^^^^^^
 
-You may also choose to clone `the ubports-boot repository <https://github.com/ubports/ubports-boot>`_ into your tree manually. It should be placed into ``BUILDDIR/halium/ubports-boot``.
+You may also choose to clone the `ubports-boot repository <https://github.com/ubports/ubports-boot>`_ into your tree manually. It should be placed into ``BUILDDIR/halium/ubports-boot``.
 
 If you share your code and build instructions, please note that you've done this.
 
@@ -63,7 +59,7 @@ With the file open, change the ``src``, or first attribute, of the ``/data`` mou
 
 Now, remove all ``context=`` options from all block devices in the file. Save and exit.
 
-For an example of this, see `this commit on universalsuperbox/android_device_motorola_potter <https://github.com/UniversalSuperBox/android_device_motorola_potter/commit/9b574967e3a6f07884760b418befe731ccfcb924>`_. Removing the ``wait`` flag is not required and was an accident.
+For an example of this, see `this commit on universalsuperbox/android_device_motorola_potter <https://github.com/UniversalSuperBox/android_device_motorola_potter/commit/9b574967e3a6f07884760b418befe731ccfcb924>`__. Removing the ``wait`` flag is not required and was an accident.
 
 
 Edit init.rc
@@ -71,7 +67,7 @@ Edit init.rc
 
 Some Android services conflict with ofono in 16.04 and will cause your device to reboot without warning, about 30-60 seconds after it boots. We will need to disable these services until the issue is resolved.
 
-To do this, open up your device's default ``init.rc`` (this is likely init.qcom.rc or init.[codename].rc), comment out any ``import`` statements, and add ``disabled`` to services like rild, qti, and others that interface with the radio. Most of them have a ``user radio`` line. For an example, see `commit 7875b48b on UniversalSuperBox/android_device_motorola_potter <https://github.com/UniversalSuperBox/android_device_motorola_potter/commit/7875b48b5b6f240935d7f327d33128e952a3589b>`_
+To do this, open up your device's default ``init.rc`` (this is likely init.qcom.rc or init.[codename].rc), comment out any ``import`` statements, and add ``disabled`` to services like rild, qti, and others that interface with the radio. Most of them have a ``user radio`` line. For an example, see `commit 7875b48b on UniversalSuperBox/android_device_motorola_potter <https://github.com/UniversalSuperBox/android_device_motorola_potter/commit/7875b48b5b6f240935d7f327d33128e952a3589b>`__
 
 
 Edit kernel config

--- a/porting/building-ubports-boot.rst
+++ b/porting/building-ubports-boot.rst
@@ -1,4 +1,3 @@
-
 Building ubports-boot
 =====================
 

--- a/porting/installing-16-04.rst
+++ b/porting/installing-16-04.rst
@@ -1,3 +1,4 @@
+
 Installing Ubuntu Touch 16.04 images on Halium
 ==============================================
 
@@ -17,19 +18,10 @@ We'll need to install the ubports-boot image before installing an image. Reboot 
     cout
     fastboot flash boot ubports-boot.img
 
-Choose a rootfs
----------------
+Download the rootfs
+-------------------
 
-Before installing a rootfs, you'll need one to install. Which one you choose will depend on whether your device uses CAF sources or not. To check if your device contains any CAF source (it probably does), do a ``grep -r [term]`` for all of the following terms in $BUILDDIR/device/MANUFACTURER/CODENAME. If any search returns hits, you have a CAF device::
-
-    QCOM_BSP
-    QTI_BSP
-    QCOM_HARDWARE
-
-* If your device includes any CAF sources, choose `the CAF rootfs <http://ci.ubports.com/job/xenial-7.1-caf-sudoku-rootfs/>`_.
-* If your device does not include any CAF sources, choose `the standard rootfs <http://ci.ubports.com/job/xenial-rootfs-armhf/>`_
-
-In either case, download the large ``tar.gz`` file under the "Last successful artifacts" heading.
+Next we'll need to download the rootfs (root filesystem) that's appropriate for your device. Right now, we only have one available. Simply download ``ubports-touch.rootfs-xenial-armhf.tar.gz`` from `our CI server <https://ci.ubports.com/job/xenial-rootfs-armhf/>`__. If you have a 64-bit ARM (aarch64) device, this same rootfs should work for you. If you have an x86 device, let us know. We do not have a rootfs available for these yet.
 
 
 Install system.img and rootfs
@@ -44,6 +36,8 @@ Download the rootstock-touch-install script from `universalsuperbox/rootstock-ng
     rootstock-touch-install path/to/rootfs.tar.gz path/to/system.img
 
 The script will copy and extract the files to their proper places, then allow you to set the phablet user's password. If it gets all the way to ``rebooting device`` and doesn't seem to produce any errors, it's time to continue to the next step. If something goes wrong, please get in touch with us. If your device doesn't reboot automatically, reboot it using your recovery's interface.
+
+If you get errors similar to ``broken pipe`` or ``out of memory``, use the ``-b`` option to push the busybox or toybox build that came from your tree. These may have fewer bugs than your recovery's busybox.
 
 
 Get SSH access

--- a/porting/installing-16-04.rst
+++ b/porting/installing-16-04.rst
@@ -1,4 +1,3 @@
-
 Installing Ubuntu Touch 16.04 images on Halium
 ==============================================
 

--- a/porting/introduction.rst
+++ b/porting/introduction.rst
@@ -1,3 +1,4 @@
+
 Porting information
 ===================
 

--- a/porting/introduction.rst
+++ b/porting/introduction.rst
@@ -1,4 +1,3 @@
-
 Porting information
 ===================
 


### PR DESCRIPTION
I added some commands to ensure that sphinx-intl gets installed to the docs build env.

Since the rootfs now supports both caf and non-caf devices, we don't need that info any more. Also, there was an update to ubports-boot so it stops messing with everyone's stuff.