### PR TITLE
Update to ssh document

### DIFF
--- a/userguide/advanceduse/ssh.rst
+++ b/userguide/advanceduse/ssh.rst
@@ -37,15 +37,8 @@ Let's assume it's stored as ``/home/phablet/id_rsa.pub``. Use the terminal app o
 
 Now start the ssh server::
 
-    sudo service ssh start
+    sudo android-gadget-service enable ssh
 
-To make sure the ssh server is automatically started in the future, execute::
-
-    sudo setprop persist.service.ssh true
-    
-In case the ssh was not enabled before, use the following command to permit ssh connexion form outside the mobile device::
-
-    android-gadget-tools ssh enable
 
 Connect
 -------


### PR DESCRIPTION
removing the setprop instructions as they are depreciated and replaced by android-gadget-service.