### PR TITLE
Display scaling information, tweak for readability

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -44,6 +44,12 @@ If you want to help improving this documentation, :doc:`the Documentation contri
 
    appdev/index
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Porting
+   :name: sec-porting
+
+   porting/introduction
 
 .. toctree::
    :maxdepth: 1
@@ -54,10 +60,3 @@ If you want to help improving this documentation, :doc:`the Documentation contri
    Ubuntu UI-Toolkit <https://api-docs.ubports.com/>
    Clickable <http://clickable.bhdouglass.com/en/latest/index.html>
    Halium <https://docs.halium.org/en/latest/index.html>
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Porting
-   :name: sec-porting
-
-   porting/introduction

--- a/porting/installing-16-04.rst
+++ b/porting/installing-16-04.rst
@@ -3,11 +3,11 @@ Installing Ubuntu Touch 16.04 images on Halium
 
 .. warning::
 
-    These steps  will wipe all of the data on your device. If there is anything that you would like to keep, ensure it is backed up and copied off of the device before continuing. It is not a good idea to port Ubuntu Touch using the device you rely on every day as a testing device. You will lose data. I speak from personal experience.
+    These steps  will wipe **all** of the data on your device. If there is anything that you would like to keep, ensure it is backed up and copied off of the device before continuing.
 
 Now that you've :doc:`built ubports-boot <building-ubports-boot>`, we'll use a script called ``rootstock-touch-install`` to install an Ubuntu Touch rootfs on your device.
 
-In order to install Ubuntu Touch, you will need a recovery with Busybox, such as TWRP, installed on your phone. You will also need ensure the /data partition is formatted with ext4 and does not have any encryption on it.
+In order to install Ubuntu Touch, you will need a recovery with Busybox, such as TWRP, installed on your phone. You will also need to ensure the /data partition is formatted with ext4 and does not have any encryption on it.
 
 Install ubports-boot
 --------------------
@@ -36,7 +36,7 @@ Download the rootstock-touch-install script from `universalsuperbox/rootstock-ng
 
 The script will copy and extract the files to their proper places, then allow you to set the phablet user's password. If it gets all the way to ``rebooting device`` and doesn't seem to produce any errors, it's time to continue to the next step. If something goes wrong, please get in touch with us. If your device doesn't reboot automatically, reboot it using your recovery's interface.
 
-If you get errors similar to ``broken pipe`` or ``out of memory``, use the ``-b`` option to push the busybox or toybox build that came from your tree. These may have fewer bugs than your recovery's busybox.
+If you get errors similar to ``broken pipe`` or ``out of memory``, use the ``-b`` option to push the busybox or toybox build that came from your tree. These may have fewer bugs than your recovery's busybox. More information about this option is available in the script's README.
 
 
 Get SSH access
@@ -52,11 +52,10 @@ Similar to the Halium reference rootfs, you should set your computer's IP on the
 
 The password will be the one that you set while running rootstock.
 
-
 Make / writeable
 ----------------
 
-Before we make any changes to the rootfs (which is in the next step), you'll need to remount it with write permissions. To do that, run the following command::
+Before we make any changes to the rootfs (which will be required for the next step), you'll need to remount it with write permissions. To do that, run the following command::
 
     sudo mount -o remount,rw /
 
@@ -70,6 +69,11 @@ Now that you're logged in, you must create some udev rules to allow Ubuntu Touch
     cat /var/lib/lxc/android/rootfs/ueventd*.rc|grep ^/dev|sed -e 's/^\/dev\///'|awk '{printf "ACTION==\"add\", KERNEL==\"%s\", OWNER=\"%s\", GROUP=\"%s\", MODE=\"%s\"\n",$1,$3,$4,$2}' | sed -e 's/\r//' >/usr/lib/lxc-android-config/70-[codename].rules
 
 Now, reboot the device. If all has gone well, you will eventually see the Ubuntu Touch spinner followed by Unity 8. Your lock password is the same as you set for SSH.
+
+Continue on
+-----------
+
+Congratulations! Ubuntu Touch has now booted on your device. Move on to :doc:`running-ut` to learn about more specific steps you will need to take for a complete port.
 
 .. todo::
 

--- a/porting/introduction.rst
+++ b/porting/introduction.rst
@@ -16,3 +16,4 @@ Start at :doc:`building-ubports-boot` if you'd like to install the UBports Ubunt
 
     building-ubports-boot
     installing-16-04
+    running-ut

--- a/porting/running-ut.rst
+++ b/porting/running-ut.rst
@@ -1,0 +1,54 @@
+Running Ubuntu Touch
+====================
+
+Display settings
+----------------
+
+When the device boots, you'll probably notice that everything is very small. There are two variables that set the content scaling for Unity 8 and Ubuntu Touch applications: ``GRID_UNIT_PX`` and ``QTWEBKIT_DPR``.
+
+There are also some other options available that may be useful for you depending on your device's form factor. These are discussed below.
+
+All of these settings are guessed by Unity 8 if none are set. There are many cases, however, where the guess is wrong (for example, very high resolution phone displays will be identified as desktop computers). To manually set a value for these variables, simply create a file at ``/etc/ubuntu-session.d/[codename].conf`` specifying them. For example, this is the file for the Nexus 7 tablet::
+
+    $ cat /etc/ubuntu-touch-session.d/flo.conf 
+    GRID_UNIT_PX=18
+    QTWEBKIT_DPR=2.0
+    NATIVE_ORIENTATION=landscape
+    FORM_FACTOR=tablet
+
+Methods for deriving values for these variables are below.
+
+Display scaling
+^^^^^^^^^^^^^^^
+
+``GRID_UNIT_PX`` (Pixels per Grid Unit or Px/GU) is specific to each device. Its goal is to make the user interface of the system and its applications the same *perceived* size regardless of the device they are displayed on. It is primarily dependent on the pixel density of the device’s screen and the distance to the screen the user is at. The latter value cannot be automatically detected and is based on heuristics. We assume that tablets and laptops are the same distance and that they are held at 1.235 times the distance phones tend to be held at.
+
+``QTWEBKIT_DPR`` sets the display scaling for the Oxide web engine, so changes to this value will affect the scale of the browser and webapps.
+
+A reference device has been chosen from which we derive the values for all other devices. The reference device is a laptop with a 120ppi screen. However, there is no exact formula since these options are set for *perceived* size rather than *physical* size . Here are some values for other devices so you may derive the correct one for yours:
+
+==============================  ==========  ============  =======  =====  ============
+Device                          Resolution  Display Size  PPI      Px/GU  QtWebKit DPR
+==============================  ==========  ============  =======  =====  ============
+'Normal' density laptop         N/A         N/A           96-150   8      1.0
+ASUS Nexus 7                    1280x800    7"            216      12     2.0
+'High' density laptop           N/A         N/A           150-250  16     1.5
+Samsung Galaxy Nexus            1280x720    4.65"         316      18     2.0
+LG Nexus 4                      1280x768    4.7"          320      18     2.0
+Samsung Nexus 10                2560x1600   10.1"         299      20     2.0
+Fairphone 2                     1080x1920   5"            440      23     2.5
+LG Nexus 5                      1080x1920   4.95"         445      23     2.5
+==============================  ==========  ============  =======  =====  ============
+
+Experiment with a few values to find one that feels good when compared to the Ubuntu Touch experience on other devices. If you are unsure of which is the best, share some pictures (including some object for scale) along with the device specs with us.
+
+Form factor
+^^^^^^^^^^^
+
+There are two other settings that may be of interest to you.
+
+``FORM_FACTOR`` specifies the device's form factor. This value is set as the device's Chassis, which you can find by running ``hostnamectl``. The acceptable values are ``handset``, ``tablet``, ``laptop`` and ``desktop``. Apps such as the gallery use this information to change their functionality. For more information on the Chassis, see `the freedesktop.org hostnamed specification`_.
+
+``NATIVE_ORIENTATION`` sets the display orientation for the device's built-in screen. This value is used whenever autorotation isn't working correctly or when an app wishes to be locked to the device's native orientation. Acceptable values are ``landscape``, which is normally used for tablets, laptops, and desktops; and ``portrait``, which is usually used for phone handsets.
+
+.. _the freedesktop.org hostnamed specification: https://www.freedesktop.org/wiki/Software/systemd/hostnamed/


### PR DESCRIPTION
Display scaling information is a needed addition since it is not listed
anywhere else.

For readability, I also:
* Moved Porting above Platform in the master table of contents
* Corrected grammar errors