### PR TITLE
system software: add core apps link

### DIFF
--- a/appdev/index.rst
+++ b/appdev/index.rst
@@ -173,7 +173,10 @@ A collection of external resources
 System Software
 ---------------
 
-Working on system components
+Ubuntu Touch image ship a set of applications also known as "core apps".
+See `core apps repositories on github <https://github.com/search?q=topic%3Acore-app+org%3Aubports&type=Repositories>`__
+
+This resource will help you get started with working on system components
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
Section "System Software" is confusing for me as i always heard about "core apps" or "system apps" but not "system software" or "system components". I did not modify titles though.  