### PR TITLE
Add information on preinstalled apps

### DIFF
--- a/appdev/index.rst
+++ b/appdev/index.rst
@@ -91,6 +91,11 @@ Learn more about app development by digging into our :ref:`Sample apps <sampleap
 
     samples/index
 
+Preinstalled apps
+-----------------
+
+The :doc:`/contribute/preinstalled-apps` page has information on developing the apps which are included with Ubuntu Touch.
+
 System Development
 ------------------
 

--- a/contribute/index.rst
+++ b/contribute/index.rst
@@ -15,4 +15,5 @@ If those aren't enough for you, see `our contribute page <https://ubports.com/pa
     quality-assurance
     documentation
     translations
+    preinstalled-apps
     monetary

--- a/contribute/preinstalled-apps.rst
+++ b/contribute/preinstalled-apps.rst
@@ -1,0 +1,90 @@
+Preinstalled apps
+=================
+
+This page will help you get started with developing the apps which are included with Ubuntu Touch.
+
+Core apps
+---------
+
+Core apps are applications which are included with UBports distributions of Ubuntu Touch **and** placed in the OpenStore for updates. Core apps are a good "first development" experience within UBports. Many are built with `Clickable`_, an easy to use build and test system for Ubuntu Touch apps. Most core apps can even be built and run without an Ubuntu Touch device!
+
+Which core apps currently exist?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A full list of the Ubuntu Touch core apps follows.
+
+.. Note for markup travelers: These links are in the "bottom of page" style so they take up less space inside the table.
+   Please sort the table alphabetically.
+   "Application Name" should be the name that displays in the apps list in English (US)
+
+================    ==================================  ============================
+Application Name    Store page                          Code repository
+================    ==================================  ============================
+Calculator          `Calculator on OpenStore`_          `calculator-app on GitHub`_
+Calendar            `Calendar on OpenStore`_            `calendar-app on GitHub`_
+Clock               `Clock on OpenStore`_               `clock-app on GitHub`_
+File Manager        `File Manager on OpenStore`_        `filemanager-app on GitHub`_
+Gallery             `Gallery on OpenStore`_             `gallery-app on GitHub`_
+Music               Not yet in OpenStore                `music-app on GitHub`_
+Notes               `Notes on OpenStore`_               `notes-app on GitHub`_
+OpenStore           `OpenStore... on OpenStore`_        `openstore-app on GitHub`_
+Terminal            `Terminal on OpenStore`_            `terminal-app on GitHub`_
+UBports Welcome     `UBports Welcome on OpenStore`_     `ubports-app on GitHub`_
+Weather             Not yet in OpenStore                `weather-app on GitHub`_
+================    ==================================  ============================
+
+Other preinstalled apps
+-----------------------
+
+The following appplications are preinstalled in Ubuntu Touch but are not considered core apps. Most of the time these projects must be updated with the system because they use many system services which do not necessarily have a stable API.
+
+These apps may be more difficult to work with, but their repository should contain a document stating how to build and run them on a device.
+
+.. Please sort this list alphabetically by the app display name in English (US)
+
+* Browser (`morph-browser on GitHub`_)
+* Contacts (`address-book-app on GitHub`_)
+* Camera (`camera-app on GitHub`_)
+* External Drives (`ciborium on GitHub`_)
+* Media Player (`mediaplayer-app on GitHub`_)
+* Messaging (`messaging-app on GitHub`_)
+* Phone (`dialer-app on GitHub`_)
+* System Settings (`system-settings on GitHub`_)
+
+Instructions for contributing to these applications can be found in their respective repositories.
+
+.. _Clickable: http://clickable.bhdouglass.com/en/latest/
+
+.. core app table links. Please put them here in the same order that you do in the table above.
+
+.. _Calculator on OpenStore: https://open-store.io/app/com.ubuntu.calculator
+.. _calculator-app on GitHub: https://github.com/ubports/calculator-app
+.. _Calendar on OpenStore: https://open-store.io/app/com.ubuntu.calendar
+.. _calendar-app on GitHub: https://github.com/ubports/calendar-app
+.. _Clock on OpenStore: https://open-store.io/app/com.ubuntu.clock
+.. _clock-app on GitHub: https://github.com/ubports/clock-app
+.. _File Manager on OpenStore: https://open-store.io/app/com.ubuntu.filemanager
+.. _filemanager-app on GitHub: https://github.com/ubports/filemanager-app
+.. _Gallery on OpenStore: https://open-store.io/app/com.ubuntu.gallery
+.. _gallery-app on GitHub: https://github.com/ubports/gallery-app
+.. _music-app on GitHub: https://github.com/ubports/music-app
+.. _Notes on OpenStore: https://open-store.io/app/com.ubuntu.reminders
+.. _notes-app on GitHub: https://github.com/ubports/notes-app
+.. _OpenStore... on OpenStore: https://open-store.io/app/openstore.openstore-team
+.. _openstore-app on GitHub: https://github.com/UbuntuOpenStore/openstore-app
+.. _Terminal on OpenStore: https://open-store.io/app/com.ubuntu.terminal
+.. _terminal-app on GitHub: https://github.com/ubports/terminal-app
+.. _UBports Welcome on OpenStore: https://open-store.io/app/com.ubuntu.ubports
+.. _ubports-app on GitHub: https://github.com/ubports/ubports-app
+.. _weather-app on GitHub: https://github.com/ubports/weather-app
+
+.. Other preinstalled apps links. Please put them here in the same order that you do in the list
+
+.. _morph-browser on GitHub: https://github.com/ubports/morph-browser
+.. _address-book-app on GitHub: https://github.com/ubports/address-book-app
+.. _camera-app on GitHub: https://github.com/ubports/camera-app
+.. _ciborium on GitHub: https://github.com/ubports/ciborium
+.. _mediaplayer-app on GitHub: https://github.com/ubports/mediaplayer-app
+.. _dialer-app on GitHub: https://github.com/ubports/dialer-app
+.. _messaging-app on GitHub: https://github.com/ubports/messaging-app
+.. _system-settings on GitHub: https://github.com/ubports/system-settings


### PR DESCRIPTION
We previously haven't had a canonical list of core apps anywhere. We do now.