### PR TITLE
Libertine bind mount

### DIFF
--- a/userguide/dailyuse/libertine.rst
+++ b/userguide/dailyuse/libertine.rst
@@ -125,10 +125,10 @@ In order to add a bind mount use::
 
   libertine-container-manager configure -i CONTAINER-IDENTIFIER -b add -p /media/phablet/ID-OF-SD
   
-You can also make deep links in case you only want parts of your SD-card available in the container. In this case just the entire path to the directory you want to bind mount. 
+You can also make deep links in case you only want parts of your SD-card available in the container. In this case just the entire path to the directory you want to bind mount::
 
   libertine-container-manager configure -i CONTAINER-IDENTIFIER -b add -p /media/phablet/ID-OF-SD/directory/you/want
-    
+  
 This will not allow the container access to any of the directories earlier in the path for anything other than accessing your mounted directory.
     
 In order to use the SD-card as extra space for your container, make sure first to format it using ext4 or similar.

--- a/userguide/dailyuse/libertine.rst
+++ b/userguide/dailyuse/libertine.rst
@@ -127,7 +127,7 @@ In order to add a bind mount use::
   
 You can also make deep links in case you only want parts of your SD-card available in the container. In this case just the entire path to the directory you want to bind mount. 
 
-    libertine-container-manager configure -i CONTAINER-IDENTIFIER -b add -p /media/phablet/ID-OF-SD/directory/you/want
+  libertine-container-manager configure -i CONTAINER-IDENTIFIER -b add -p /media/phablet/ID-OF-SD/directory/you/want
     
 This will not allow the container access to any of the directories earlier in the path for anything other than accessing your mounted directory.
     

--- a/userguide/dailyuse/libertine.rst
+++ b/userguide/dailyuse/libertine.rst
@@ -123,7 +123,7 @@ In order to access your SD-card or any other part of the regular filesystem from
 
 In order to add a bind mount use::
 
-  libertine-container-manager configure -i CONTAINER-IDENTIFIER -b add /media/phablet/ID-OF-SD
+  libertine-container-manager configure -i CONTAINER-IDENTIFIER -b add -p /media/phablet/ID-OF-SD
   
 You can also make deep links in case you only want parts of your SD-card available in the container.
 In order to use the SD-card as extra space for your container, make sure first to format it using ext4 or similar.

--- a/userguide/dailyuse/libertine.rst
+++ b/userguide/dailyuse/libertine.rst
@@ -116,6 +116,19 @@ To get a shell as user ``phablet`` run::
 .. note::
     When you launch bash in this way you will not get any specific feedback to confirm that you are now *inside* the container. You can check ``ls /`` to confirm for yourself that you are inside the container. The listing of ``ls /`` will be different inside and outside of the container.
 
+Accessing SD card
+^^^^^^^^^^^^^^^^^
+
+In order to access your SD-card or any other part of the regular filesystem from inside your libertine container you must create a bind mount. This requires your SD card to be automounted each time you boot the device.
+
+In order to add a bind mount use::
+
+  libertine-container-manager configure -i CONTAINER-IDENTIFIER -b add /media/phablet/ID-OF-SD
+  
+You can also make deep links in case you only want parts of your SD-card available in the container.
+In order to use the SD-card as extra space for your container, make sure first to format it using ext4 or similar.
+There is a "feature" in udisk2 that mounts SD-cards that ensures only files ending in .bat, .exe or .com can be executed from the drive if it is (v)fat formatted.
+
 Shortcuts
 ^^^^^^^^^
 

--- a/userguide/dailyuse/libertine.rst
+++ b/userguide/dailyuse/libertine.rst
@@ -119,15 +119,20 @@ To get a shell as user ``phablet`` run::
 Accessing SD card
 ^^^^^^^^^^^^^^^^^
 
-In order to access your SD-card or any other part of the regular filesystem from inside your libertine container you must create a bind mount. This requires your SD card to be automounted each time you boot the device.
+In order to access your SD-card or any other part of the regular filesystem from inside your libertine container you must create a bind mount.
 
 In order to add a bind mount use::
 
   libertine-container-manager configure -i CONTAINER-IDENTIFIER -b add -p /media/phablet/ID-OF-SD
   
-You can also make deep links in case you only want parts of your SD-card available in the container.
+You can also make deep links in case you only want parts of your SD-card available in the container. In this case just the entire path to the directory you want to bind mount. 
+
+    libertine-container-manager configure -i CONTAINER-IDENTIFIER -b add -p /media/phablet/ID-OF-SD/directory/you/want
+    
+This will not allow the container access to any of the directories earlier in the path for anything other than accessing your mounted directory.
+    
 In order to use the SD-card as extra space for your container, make sure first to format it using ext4 or similar.
-There is a "feature" in udisk2 that mounts SD-cards that ensures only files ending in .bat, .exe or .com can be executed from the drive if it is (v)fat formatted.
+There is a mis-feature in udisk2 that mounts SD-cards (showexec) that ensures only files ending in .bat, .exe or .com can be executed from the drive if it is (v)fat formatted. This has been changed in other distributions allowing any file to have execute priviliges, but not ubuntu. The reccomended workaround is to add a udev rule to control how to mount a card with a given id, but since the udev rules are on the read only port on touch, this is not possible.
 
 Shortcuts
 ^^^^^^^^^


### PR DESCRIPTION
Added documentation on libertine-container-manager bind mounts so that SD-cards can be accessed