### PR TITLE
Use workspace as home for pip

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,8 @@
 def install_dependencies = {
-    sh 'pip install --no-cache-dir --upgrade -r requirements.txt'
+    sh 'pip install --no-cache-dir --user --upgrade -r requirements.txt'
 }
 def build_docs = {
-    sh 'sphinx-build -Wab html . _build/html/'
-}
-def clean_up = {
-    sh 'git clean -fdx'
+    sh 'python3 -m sphinx -Wab html . _build/html/'
 }
 pipeline {
     agent none
@@ -14,14 +11,19 @@ pipeline {
             agent {
                 docker {
                     image "python:3.7"
-                    args '--user 0:0'
                 }
             }
             steps {
-                script {install_dependencies()}
-                script {build_docs()}
-                archiveArtifacts artifacts: '_build/html/', onlyIfSuccessful: true
-                script {clean_up()}
+                withEnv(["HOME=${env.WORKSPACE}"]) {
+                    script {install_dependencies()}
+                    script {build_docs()}
+                    archiveArtifacts artifacts: '_build/html/', onlyIfSuccessful: true
+                }
+            }
+            post {
+                cleanup {
+                    cleanWs()
+                }
             }
         }
     }

--- a/conf.py
+++ b/conf.py
@@ -69,7 +69,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.md']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.md', '.local']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'


### PR DESCRIPTION
To avoid running as root inside our docker container, we can use the workspace (which we have write access to) as our HOME. Then, if Sphinx ignores the place we installed packages, we have a working build!

I wanted to use `withEnv("[PATH+PYTHON=${env.WORKSPACE}/.local/bin"])` so we could run `sphinx-build` rather than `python3 -m sphinx`, but we can't do that thanks to a Jenkins bug: https://issues.jenkins-ci.org/browse/JENKINS-49076