### PR TITLE
fix(rtd): fix `sphinx_rtd_theme` lines in tables do not wrap by default

### DIFF
--- a/_static/css/ubports.css
+++ b/_static/css/ubports.css
@@ -17,3 +17,17 @@ p {
 .icon-home {
     font-size: 0 !important;
 }
+
+/* override table width restrictions */
+.wy-table-responsive table th
+, .wy-table-responsive table td
+{
+    /* !important prevents the common CSS stylesheets from
+       overriding this as on RTD they are loaded after this stylesheet */
+    white-space: normal !important;
+}
+
+.wy-table-responsive
+{
+    overflow: visible !important;
+}


### PR DESCRIPTION
* `sphinx_rtd_theme` known issue: long lines in tables do not wrap by default
  - https://github.com/rtfd/sphinx_rtd_theme/issues/117

---

Nothing appears to be affected by this theme bug at the moment but it still exists.  This CSS fix will prevent it from plaguing these docs.  Here's a test table that will show the problem:

```rst
.. list-table::
    :name: commit-type-vs-version-bump
    :header-rows: 1
    :stub-columns: 0
    :widths: 1,2,3,1,1

    * - Type
      - Heading
      - Description
      - Bump (default)
      - Bump (custom)
    * - ``build``
      - Build System
      - Changes related to the build system
      - –
      - 
    * - ``chore``
      - –
      - Changes to the build process or auxiliary tools and libraries such as documentation generation
      - –
      - 
    * - ``ci``
      - Continuous Integration
      - Changes to the continuous integration configuration
      - –
      - 
    * - ``docs``
      - Documentation
      - Documentation only changes
      - –
      - 0.0.1
    * - ``feat``
      - Features
      - A new feature
      - 0.1.0
      - 
    * - ``fix``
      - Bug Fixes
      - A bug fix
      - 0.0.1
      - 
    * - ``perf``
      - Performance Improvements
      - A code change that improves performance
      - 0.0.1
      - 
    * - ``refactor``
      - Code Refactoring
      - A code change that neither fixes a bug nor adds a feature
      - –
      - 0.0.1
    * - ``revert``
      - Reverts
      - A commit used to revert a previous commit
      - –
      - 0.0.1
    * - ``style``
      - Styles
      - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
      - –
      - 0.0.1
    * - ``test``
      - Tests
      - Adding missing or correcting existing tests
      - –
      - 0.0.1
```

Place that in one of the docs and build it.  The long lines won't wrap and the table will need to be horizontally scrolled for the content to be visible.  This CSS will wrap the long lines instead.