### PR TITLE
Update libertine.rst

### DIFF
--- a/userguide/dailyuse/libertine.rst
+++ b/userguide/dailyuse/libertine.rst
@@ -3,7 +3,7 @@ Run desktop applications
 
 Libertine allows you to use standard desktop applications in Ubuntu Touch.
 
-To display and launch applications you need the *Desktop Apps Scope* which is available in the `Open Store <https://open-store.io/app/libertine-scope.ubuntu>`_. To install applications you need to use the commandline as described below.
+To display and launch applications you need the *Desktop Apps Scope* which is available by swiping from the bottom of your device, and then tapping on the star. To install applications you need to use the commandline as described below.
 
 Manage containers
 -----------------


### PR DESCRIPTION
Updated the string about "Desktop Apps Scope" because it's installed by default on xenial, and the step to install it from OpenStore is no longer necessary.