### PR TITLE
Add note about emulator-5558 offline issue

### DIFF
--- a/userguide/dailyuse/anbox.rst
+++ b/userguide/dailyuse/anbox.rst
@@ -65,6 +65,12 @@ You can check that adb server is correctly running locally on your phone by open
     phablet@ubuntu-phablet:~$ adb devices  
     List of devices attached  
     emulator-5558	device  
+    
+If you get ``emulator-5558  offline`` :
+
+1. Find the pid of anbox owned by phablet with `` top | grep anbox``
+2. Kill the process (it will restart by itself) ``kill xxxx  #xxxx the pid number``
+
 
 How to install new APKs
 -----------------------


### PR DESCRIPTION
Got the issue `emulator-5558 offline` on Oneplus One.
Solved by restarting anbox, thanks to [this upstream issue](https://github.com/anbox/anbox/issues/75).

Added note to the doc