### PR TITLE
Update the name of QtUbuntu's logging rule

### DIFF
--- a/systemdev/qtmir-qtubuntu.rst
+++ b/systemdev/qtmir-qtubuntu.rst
@@ -31,7 +31,7 @@ Since QtUbuntu is used directly by apps, any logging output from it will be loca
 
 .. code-block:: sh
 
-    initctl set-env QT_LOGGING_RULES='ubuntumirclient.*=true'
+    initctl set-env QT_LOGGING_RULES='qt.qpa.mirclient.*=true'
 
 We plan to replace QtUbuntu with QtWayland in the future.
 


### PR DESCRIPTION
QtUbuntu's logging rule's name has changed, presumably since the edge
merge. This commit updates the document to match the current name.