### PR TITLE
Update writeable-dirs.rst: Qt app name and clickable app name need to match

### DIFF
--- a/appdev/guides/writeable-dirs.rst
+++ b/appdev/guides/writeable-dirs.rst
@@ -39,6 +39,8 @@ The Qt header ``QStandardPaths`` provides the app's writable locations in C++:
     QString appDataPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     ...
 
+Since the value of the QStandardPaths strings are decided by the `Qt application name <https://doc.qt.io/qt-5/qcoreapplication.html#applicationName-prop>`_, this needs to be the same as the clickable application name.
+
 Using Standard Paths in QML
 ---------------------------
 The Qt module `Qt.labs.platform <https://doc.qt.io/archives/qt-5.10/qml-qt-labs-platform-standardpaths.html>`_ provides the app's writable locations in QML:


### PR DESCRIPTION
Adding a note about the Qt application name needing to match the clickable application name for these paths to work.
In my case they were not the same, and trying to write to QStandardPaths::AppDataLocation, since the directory did not exist and was not a writable directory.