### PR TITLE
Fix typo in chown command

### DIFF
--- a/userguide/advanceduse/ssh.rst
+++ b/userguide/advanceduse/ssh.rst
@@ -33,7 +33,7 @@ Let's assume it's stored as ``/home/phablet/id_rsa.pub``. Use the terminal app o
     chmod 700 /home/phablet/.ssh
     cat /home/phablet/id_rsa.pub >> /home/phablet/.ssh/authorized_keys
     chmod 600 /home/phablet/.ssh/authorized_keys 
-    chown -R phablet.phablet /home/phablet/.ssh
+    chown -R phablet:phablet /home/phablet/.ssh
 
 Now start the ssh server::
 


### PR DESCRIPTION
Closes ubports/docs.ubports.com#314

Signed-off-by: Ben Court <git@bencourt.co.uk>