### PR TITLE
Add redirects from old porting pages with Rediraffe

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ def install_dependencies = {
 }
 def build_docs = {
     sh 'python3 -m sphinx -Wab html . _build/html/'
+    sh 'python3 -m sphinx -Wab rediraffecheckdiff . _build/html'
 }
 def link_index = {
     sh 'cp redir.html _build/html/..index.html'
@@ -17,6 +18,10 @@ pipeline {
                 }
             }
             steps {
+                // Workaround to create the master branch since Jenkins
+                // refuses to do it on PR builds
+                sh 'git branch master `git show-ref -s origin/master`'
+
                 withEnv(["HOME=${env.WORKSPACE}"]) {
                     script {install_dependencies()}
                     script {build_docs()}

--- a/build.sh
+++ b/build.sh
@@ -22,9 +22,11 @@ else
   pip install -r requirements.txt
 fi
 echo -e "${GREEN}Building...${PLAIN}"
+rm -r _build/
 if [ "$(uname)" == "Linux" ]; then
-  sphinx-build -Wa . _build/html -j `nproc --all`
+  sphinx-build -Wa . _build/html -j `nproc --all` || exit $?
 else
-  sphinx-build -Wa . _build/html -j `sysctl -n hw.ncpu`
+  sphinx-build -Wa . _build/html -j `sysctl -n hw.ncpu` || exit $?
 fi
+sphinx-build -Wab rediraffecheckdiff . _build/html
 exit $?

--- a/conf.py
+++ b/conf.py
@@ -31,7 +31,8 @@
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.todo'
+    'sphinx.ext.todo',
+    'sphinxext.rediraffe'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -103,6 +104,9 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+rediraffe_redirects = "redirects.txt"
+rediraffe_branch = "master"
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/contribute/documentation.rst
+++ b/contribute/documentation.rst
@@ -104,6 +104,27 @@ You can do this by adding the page to the ``index.rst`` file in the same directo
 
 The order matters. If you would like your page to appear in a certain place in the table of contents, place it there. In the previous example, newpage would be added to the end of this table of contents.
 
+Moving pages
+^^^^^^^^^^^^
+
+Sometimes it becomes necessary to move a page from one place in the documentation to another. Generally this is to improve document flow: For example, it makes more sense for the page to come after a page you've just added in a different section.
+
+However, people link to our documentation from many sources that we do not control. Blogs, websites, and other documentation sites can direct people here using links that they may never update. It is a terrible experience to follow a link from a different site and land on a 404 page, left to your own devices to find your way in restructured documentation.
+
+We use a tool called Rediraffe to avoid this bad experience. Rediraffe creates redirect pages which can send a user from an old, invalid link to a new, useful link. Please create a redirect link when changing a page's name or moving a page within the documentation's directory structure. Redirect links are created by placing the filename of the old document and the filename of the new document, relative to the documentation's root, in the `redirects.txt file <https://github.com/ubports/docs.ubports.com/blob/master/redirects.txt>`_.
+
+We use Rediraffe's ``checkdiff`` builder to ensure that pages are not deleted from the documentation without a redirect in place. This builder is run as part of the ``build.sh`` script in the repository and as part of our automated build once you submit a Pull Request.
+
+What follows are some examples of situations where you should create redirects.
+
+You are moving ``systemdev/calendars.rst`` to ``appdev/calendars.rst``. Add the following to the ``redirects.txt`` file::
+
+    "systemdev/calendars.txt" "appdev/calendars.txt"
+
+You are moving ``appdev/clickable.rst`` into several pages in ``appdev/clickable/`` to give significantly more information about the tool than there was previously. You have created an introduction page, ``appdev/clickable/introduction.rst``. In this case, it would be a good idea to redirect the old page to the new introduction page. This can be done by adding the following to ``redirects.txt``::
+
+    "appdev/clickable.rst" "appdev/clickable/introduction.rst"
+
 Warnings
 ^^^^^^^^
 

--- a/redirects.txt
+++ b/redirects.txt
@@ -1,0 +1,7 @@
+"porting/introduction.rst" "porting/Intro.rst"
+"porting/building-halium-boot.rst" "porting/halium_7-1/Building.rst"
+"porting/common-problems-install.rst" "porting/halium_7-1/Common_errors.rst"
+"porting/common-problems-run.rst" "porting/halium_7-1/Common_errors.rst"
+"porting/running-ut.rst" "porting/halium_7-1/Unity8.rst"
+"porting/installing-16-04.rst" "porting/halium_7-1/Installing.rst"
+"porting/device-configuration.rst" "porting/halium_7-1/Configuring.rst"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx_rtd_theme
 sphinx-intl
+sphinxext-rediraffe


### PR DESCRIPTION
The merge of #342[1] brought some awesome new content, but it also removed some pages. We have links to these pages elsewhere (other documentation, our website, blogs) and it would be a shame to send those to a 404.

To fix this, set up Rediraffe to check for files removed in the current branch. This will warn us in CI output when a file is removed without a redirect. By adding the 'rediraffecheckdiff' build at the end of build.sh, people can easily check their own docs.

Rediraffe also allows *creating* redirects from the newly nonexistent pages, so we'll start with the recently-removed porting pages in redirects.txt.