### PR TITLE
Switch to Python3 in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,3 +31,5 @@ else
   sphinx-build -Wa . _build/html -j `sysctl -n hw.ncpu` || exit $?
 fi
 sphinx-build -Wab rediraffecheckdiff . _build/html
+
+echo "Open _build/html/index.html in your browser to navigate through the docs"

--- a/build.sh
+++ b/build.sh
@@ -13,13 +13,13 @@ if [ -d "$HOME/ubportsdocsenv" ]; then
 else
   echo -e "${RED}No build environment found.${PLAIN}"
   echo -e "${YELLOW}Installing pip and virtualenv.${PLAIN}"
-  sudo apt install python-pip
-  sudo -H pip install virtualenv
+  sudo apt install python3-pip
+  sudo -H pip3 install virtualenv
   echo -e "${YELLOW}Creating a virtual environment in ${HOME}/ubportsdocsenv.${PLAIN}"
   virtualenv ~/ubportsdocsenv
   . ~/ubportsdocsenv/bin/activate
   echo -e "${YELLOW}Installing build tools and prerequisites.${PLAIN}"
-  pip install -r requirements.txt
+  pip3 install -r requirements.txt
 fi
 echo -e "${GREEN}Building...${PLAIN}"
 rm -r _build/

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -Eeou pipefail
+
 # color codes
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -22,11 +24,10 @@ else
   pip3 install -r requirements.txt
 fi
 echo -e "${GREEN}Building...${PLAIN}"
-rm -r _build/
+rm -rf _build/
 if [ "$(uname)" == "Linux" ]; then
   sphinx-build -Wa . _build/html -j `nproc --all` || exit $?
 else
   sphinx-build -Wa . _build/html -j `sysctl -n hw.ncpu` || exit $?
 fi
 sphinx-build -Wab rediraffecheckdiff . _build/html
-exit $?


### PR DESCRIPTION
This MR
* switches build script from Python 2  to Python 3
* Makes the build script fail properly on errors instead of just continue with the next step
* Prints the path to the entry point to open for navigating

Python 2 reached end of life and is not preinstalled on most distros nowadays. Python 3 in contrast should be available and installed everywhere.
