### PR TITLE
Avoid expanding export PATH command in crossbuilder setup

### DIFF
--- a/systemdev/testing-locally.rst
+++ b/systemdev/testing-locally.rst
@@ -32,9 +32,9 @@ Start by installing Crossbuilder on your host::
 
 Crossbuilder is a shell script, so you don't need to build it. Instead, you will need to add its directory to your ``PATH`` environment variable, so that you can execute it from any directory::
 
-    echo "export PATH=$HOME/crossbuilder:$PATH" >> ~/.bashrc
-    # and add it to your own session:
-    export PATH="$HOME/crossbuilder:$PATH"
+    echo 'export PATH="$HOME/crossbuilder:$PATH"' >> ~/.bashrc
+    # and add it to your current session:
+    source ~/.bashrc
 
 Now that Crossbuilder is installed, we can use it to set up LXD::
 


### PR DESCRIPTION
```
echo "export PATH=$HOME/crossbuilder:$PATH" >> ~/.bashrc
```
results in `$PATH` being replace by the current content of the `PATH` variable while it is appended to `~/.bashrc`. You definitely do  not what that as it will overwrite whatever is in `PATH` the time it is applied in the future. This MR fixes that by add `'`s arround the line to appended to `~/.bashrc`. 