### PR TITLE
Specify sphinx>2 so it is always installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx>2
 sphinx_rtd_theme
 sphinx-intl
 sphinxext-rediraffe


### PR DESCRIPTION
See https://github.com/ubports/docs.ubports.com/issues/355 for a better explanation of why this is needed.