### PR TITLE
Jenkinsfile: Check if the master branch exists

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
             steps {
                 // Workaround to create the master branch since Jenkins
                 // refuses to do it on PR builds
-                sh 'git branch master `git show-ref -s origin/master`'
+                sh 'git show-ref --verify --quiet master || git branch master `git show-ref -s origin/master`'
 
                 withEnv(["HOME=${env.WORKSPACE}"]) {
                     script {install_dependencies()}


### PR DESCRIPTION
If the line 'git branch master \`git show-ref -s origin/master\`' ran on a build of the master branch, the build failed. Git cannot create a new branch called 'master' when it already exists.

To avoid this problem, check if the 'master' branch exists before creating it.