### PR TITLE
Remove freenode

### DIFF
--- a/porting/index.rst
+++ b/porting/index.rst
@@ -88,7 +88,6 @@ When you run into trouble, and you will, refer to one or more of the sources bel
 * `Telegram: @halium <https://t.me/halium>`_
 * `Telegram: @ubports_porting <https://t.me/ubports_porting>`_
 * `The UBports Forum <https://forums.ubports.com/category/33/porting>`_
-* IRC: #halium on Freenode 
 * Matrix: #halium:matrix.org 
 
 .. _General-advice:


### PR DESCRIPTION
Halium is no longer on freenode. It has no IRC presence at all for the moment.