### PR TITLE
Update 20.04 python3-markdown

### DIFF
--- a/porting/introduction/Setting_up.rst
+++ b/porting/introduction/Setting_up.rst
@@ -52,7 +52,7 @@ Install the required dependencies::
     zip bzr curl libc6-dev libncurses5-dev:i386 x11proto-core-dev \
     libx11-dev:i386 libreadline6-dev:i386 libgl1-mesa-glx:i386 \
     libgl1-mesa-dev g++-multilib mingw-w64-i686-dev tofrodos \
-    python-markdown libxml2-utils xsltproc zlib1g-dev:i386 schedtool \
+    python3-markdown libxml2-utils xsltproc zlib1g-dev:i386 schedtool \
     liblz4-tool bc lzop imagemagick libncurses5 rsync \
     python-is-python3
 


### PR DESCRIPTION
```sh
lsb_release -r && apt search python-markdown | grep python3-markdown
Release:	20.04

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

python3-markdown/hirsute,hirsute,now 3.3.4-1 all [installed]
```