### PR TITLE
Reduce kept files in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         }
     }
     options {
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '180'))
+        buildDiscarder(logRotator(daysToKeepStr: '120'))
     }
     environment {
         HOME = "${env.WORKSPACE}"


### PR DESCRIPTION
daysToKeepStr deletes the entire build, not just the artifacts, after the days value is reached.

We can reduce the number of days we keep the builds too.