### PR TITLE
Porting corrections

### DIFF
--- a/porting/build_and_boot/H7_build.rst
+++ b/porting/build_and_boot/H7_build.rst
@@ -39,8 +39,8 @@ Then, from the root of your BUILDDIR, run::
 
 You may have to do this twice. It will likely fix things both times. Then, run the script without the ``-w`` flag to see if there are any more errors. If there are, fix them manually. Once finished, run the script without the ``-w`` flag one more time to make sure everything is correct.
 
-Halium-7.1 based Ubuntu Touch requires setting console=tty0
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Ubuntu Touch requires setting console=tty0
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The halium-boot initramfs expects ``/dev/console`` to be a console device and will not start init if it is not available. This is commonly the case on recent devices, because they either have UART disabled or ``console=`` is not specified (null) by default. This can be fixed by supplying ``console=tty0`` as the last argument in the kernel cmdline. To achieve this, proceed as follows:
 

--- a/porting/build_and_boot/H9_build.rst
+++ b/porting/build_and_boot/H9_build.rst
@@ -42,6 +42,28 @@ Then, from the root of your ``BUILDDIR``, run::
 
 You may have to do this twice. It will likely fix things both times. Then, run the script without the ``-w`` flag to see if there are any more errors. If there are, fix them manually. Once finished, run the script without the ``-w`` flag one more time to make sure everything is correct.
 
+Ubuntu Touch requires setting console=tty0
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The halium-boot initramfs expects ``/dev/console`` to be a console device and will not start init if it is not available. This is commonly the case on recent devices, because they either have UART disabled or ``console=`` is not specified (null) by default. This can be fixed by supplying ``console=tty0`` as the last argument in the kernel cmdline. To achieve this, proceed as follows:
+
+It should be done in the makefile named ``BoardConfig.mk`` (or ``BoardConfigCommon.mk``) located in the root directory of your device tree, e.g. ``~/halium/device/<vendor>/<model_codename>/BoardConfig.mk``
+
+Add the following line::
+
+    BOARD_KERNEL_CMDLINE += console=tty0
+
+If your makefile already includes a line beginning with ``BOARD_KERNEL_CMDLINE``, you may add it just below that to keep things tidy.
+
+.. Note::
+    The above method, although the preferred one, may not work for some Samsung devices. The result will be that you cannot get access to the device through ssh after boot, and Unity 8 will not be able to start. If you run into this problem, you can specify the setting in your device's kernel config file instead. Add the following lines::
+
+        CONFIG_CMDLINE="console=tty0"
+        CONFIG_CMDLINE_EXTEND=y
+
+.. Note::
+    In rare cases the bootloader overwrites the kernel command line argument, rendering the setting above useless. This is the case for the Google Pixel 3a (sargo). To deal with this issue, replicate `this commit <https://github.com/fredldotme/android_kernel_google_bonito/commit/d0741dded3907f2cf4ecdc02bfcb74fc252763ff>`_. 
+
 Build
 ^^^^^
 

--- a/porting/configure_test_fix/Lomiri.rst
+++ b/porting/configure_test_fix/Lomiri.rst
@@ -25,10 +25,21 @@ Before you make any changes to the rootfs (which will be required for the next s
 Create and add udev rules
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You must create some udev rules to allow Ubuntu Touch software to access your hardware. Run the following command, replacing [CODENAME] with your device's codename::
+You must create some udev rules to allow Ubuntu Touch software to access your hardware. 
+
+If you are building a Halium-7.1 based port, run the following command, replacing [CODENAME] with your device's codename::
 
     sudo -i # And enter your password
     cat /var/lib/lxc/android/rootfs/ueventd*.rc|grep ^/dev|sed -e 's/^\/dev\///'|awk '{printf "ACTION==\"add\", KERNEL==\"%s\", OWNER=\"%s\", GROUP=\"%s\", MODE=\"%s\"\n",$1,$3,$4,$2}' | sed -e 's/\r//' >/usr/lib/lxc-android-config/70-[CODENAME].rules
+    
+For a Halium-9.0 based port you should use the commands below, again replacing [CODENAME] with your device's codename::
+
+    sudo -i # And enter your password
+    DEVICE=[CODENAME]
+    cat /var/lib/lxc/android/rootfs/ueventd*.rc /vendor/ueventd*.rc | grep ^/dev | sed -e 's/^\/dev\///' | awk '{printf "ACTION==\"add\", KERNEL==\"%s\", OWNER=\"%s\", GROUP=\"%s\", MODE=\"%s\"\n",$1,$3,$4,$2}' | sed -e 's/\r//' >/etc/udev/rules.d/70-$DEVICE.rules
+
+.. Note::
+    If you are building a Halium-9.0 based port for a non-treble device, i.e. a device without a separate vendor partition, the command above will give an error. Simply edit and remove the following string from the command: ``/vendor/ueventd*.rc``.
 
 Now, reboot the device. If all has gone well, you will eventually see the Ubuntu Touch spinner followed by Unity 8. Your lock password is the same as you set for SSH.
 


### PR DESCRIPTION
Added missing section on console=tty0 for halium-9 plus the correct udev rules command for halium-9 which was previously only found in the porting notes wiki.