### PR TITLE
links now point to actively developed gitlab repo rather than archived github repos

### DIFF
--- a/contribute/preinstalled-apps.rst
+++ b/contribute/preinstalled-apps.rst
@@ -45,13 +45,13 @@ These apps may be more difficult to work with, but their repository should conta
 .. Please sort this list alphabetically by the app display name in English (US)
 
 * Browser (`morph-browser on GitHub`_)
-* Contacts (`address-book-app on GitHub`_)
+* Contacts (`address-book-app on GitLab`_)
 * Camera (`camera-app on GitLab`_)
-* External Drives (`ciborium on GitHub`_)
+* External Drives (`ciborium on GitLab`_)
 * Media Player (`mediaplayer-app on GitHub`_)
 * Messaging (`messaging-app on GitHub`_)
 * Phone (`dialer-app on GitHub`_)
-* System Settings (`system-settings on GitHub`_)
+* System Settings (`system-settings on GitLab`_)
 
 Instructions for contributing to these applications can be found in their respective repositories.
 
@@ -85,10 +85,10 @@ Instructions for contributing to these applications can be found in their respec
 .. Other preinstalled apps links. Please put them here in the same order that you do in the list
 
 .. _morph-browser on GitHub: https://github.com/ubports/morph-browser
-.. _address-book-app on GitHub: https://github.com/ubports/address-book-app
+.. _address-book-app on GitLab: https://gitlab.com/ubports/core/address-book-app
 .. _camera-app on GitLab: https://gitlab.com/ubports/apps/camera-app
-.. _ciborium on GitHub: https://github.com/ubports/ciborium
+.. _ciborium on GitLab: https://gitlab.com/ubports/core/ciborium
 .. _mediaplayer-app on GitHub: https://github.com/ubports/mediaplayer-app
 .. _dialer-app on GitHub: https://github.com/ubports/dialer-app
 .. _messaging-app on GitHub: https://github.com/ubports/messaging-app
-.. _system-settings on GitHub: https://github.com/ubports/system-settings
+.. _system-settings on GitLab: https://gitlab.com/ubports/core/lomiri-system-settings

--- a/systemdev/testing-locally.rst
+++ b/systemdev/testing-locally.rst
@@ -18,7 +18,7 @@ crossbuilder can be quicker for subsequent builds since the LXD container persis
 sbuild automatically creates a log file and runs `lintian <https://lintian.debian.org/manual/lintian.html>`__ on the built packages in order to detect any problems.
 The use of LXD by crossbuilder also allows for easier inspection, debugging and manual modification of the build environment. crossbuilder can also automatically deploy build packages on a connected device via ADB.
 
-We'll examine the use of crossbuilder and builds on the device using `address-book-app <https://github.com/ubports/address-book-app>`__ (the Contacts application) as an example.
+We'll examine the use of crossbuilder and builds on the device using `address-book-app <https://gitlab.com/ubports/core/address-book-app>`__ (the Contacts application) as an example.
 
 We only recommend developing packages using a device with Ubuntu Touch installed from the devel channel. This ensures that you are testing your changes against the most current state of the Ubuntu Touch code.
 
@@ -288,7 +288,7 @@ Additionally, you probably want to install ``git`` in order to get your app's so
 
 Once you're finished, you can retrieve the source for an app (in our example, the address book) and move into its directory::
 
-    git clone https://github.com/ubports/address-book-app.git
+    git clone https://gitlab.com/ubports/core/address-book-app.git
     cd address-book-app
 
 Now, you are ready to build the package::


### PR DESCRIPTION
The PR fixes the links on https://docs.ubports.com/en/latest/contribute/preinstalled-apps.html and https://docs.ubports.com/en/latest/systemdev/testing-locally.html.The  links now point to actively developed gitlab repo rather than archived github repos.

As request  in the previous PR comment (https://github.com/ubports/docs.ubports.com/pull/481#issuecomment-1013938487) ,No changes have been in pot & po files .
