### PR TITLE
Rewrite section on overlay files

### DIFF
--- a/porting/configure_test_fix/Overlay.rst
+++ b/porting/configure_test_fix/Overlay.rst
@@ -12,6 +12,15 @@ The way how overlay files are implemented and their limitations vary across buil
 
 In general, there are two methods of implementing overlay files, one is to directly copy them to the destination path potentially overwriting existing files, the other is to place them in a designated base directory from where they are then mounted onto their destination path during the boot process. The former is only possible when doing builds using the GitLab CI scripts. In case of Ubuntu Touch 16.04 it is the only available overlay mechanism. While the ``system.img`` build process allows overwriting files on the built Android system partition it has no means of doing so on the root filesystem. Ubuntu Touch 16.04 does however offer limited support of mount-based overlay files. Starting from Ubuntu Touch 20.04, the implementation of mount-based overlay files has become more powerful in terms of overlaying both files and directories in vendor and Android images regardless of the build method. The use of mount-based overlay files is generally preferable as it allows for delta OTA updates. Both mechanisms will be discussed in detail below before describing how overlay files are included into the build process in full system image builds and builds based on GitLab CI scripts.
 
+.. Note::
+
+    Some ports of Ubuntu Touch 16.04 using the GitLab CI-based build method add custom scripts or configuration files (e.g. in ``/usr/sbin/mount-android.sh``, ``/etc/init/mount-android.conf``, or a file in ``/etc/init/``) in order to overlay files below ``/android/system`` which would otherwise not be possible using this build method. This practice is strongly discouraged for a several reasons:
+
+    - overwriting a system script prevents the port from receiving future updates of that script
+    - different ports coming up with custom solutions creates confusion among new porters and contributors
+
+    Porters which are in need of overlaying files inside a GSI-based ``/android/system.img`` may want to consider using the full ``system.img`` build method instead.
+
 The implementations and limitations can be summarized as follows:
 
 +---------------------------+-------------------------------------------------+--------------------------------------------------------------------------------+

--- a/porting/configure_test_fix/Overlay.rst
+++ b/porting/configure_test_fix/Overlay.rst
@@ -19,20 +19,18 @@ If your port is based on Gitlab CI scripts, it is actually possible to not only 
 Overlay method for full system.img builds
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In your device directory, create a subdirectory named 'ubuntu'. Collect the files you wish to inject into your build in this directory. 
+In your device directory, create a subdirectory named 'ubuntu'. Collect the files you wish to inject into your build in this directory.
 
 Relevant files are for example (but this list is incomplete):
-    * 70-android.rules
-    * android.conf (for display scaling, see below)
-    * touch.pa (for pulseaudio sound configuration/initialization, see below)
+    * ``/lib/udev/rules.d/70-android.rules``
+    * ``/etc/ubuntu-touch-session.d/android.conf`` (for display scaling, see below)
 
 These files are then injected by adding a code block to the file ``device.mk`` in your device directory. For the three files above add the following code::
 
     ### Ubuntu Touch ###
     PRODUCT_COPY_FILES += \
         $(LOCAL_PATH)/ubuntu/70-android.rules:system/halium/lib/udev/rules.d/70-android.rules \
-        $(LOCAL_PATH)/ubuntu/android.conf:system/halium/etc/ubuntu-touch-session.d/android.conf \
-        $(LOCAL_PATH)/ubuntu/touch.pa:system/halium/etc/pulse/touch.pa 
+        $(LOCAL_PATH)/ubuntu/android.conf:system/halium/etc/ubuntu-touch-session.d/android.conf
     ### End Ubuntu Touch ###
 
 The first of these three files, 70-android.rules, is the one you created when bringing up Lomiri. You can extract this file from the device using ``adb pull`` or ``scp`` and copy it to the 'ubuntu' directory of your device source tree, making sure to add the corresponding line to your ``device.mk`` file, as described above.
@@ -49,7 +47,7 @@ The general steps to follow are thus:
 
 .. Note::
 
-    The target paths for the files mentioned above are *not* randomly chosen. You must use the specified paths. 
+    The target paths for the files mentioned above are *not* randomly chosen. You must use the specified paths.
 
 .. Note::
 

--- a/porting/configure_test_fix/Overlay.rst
+++ b/porting/configure_test_fix/Overlay.rst
@@ -3,91 +3,53 @@
 Overlay file method
 ===================
 
-The UBports rootfs comes with a set of standard configuration files for a number of features such as display scaling, sound, bluetooth and more. These files may not tailored to the needs of your specific device and must therefore to be replaced in order for the feature in question to function as it should. This is done with overlay files, i.e. files that the original files get overwritten with. In other words, you need to rewrite the files in question, making the necessary adjustments for your device, and then see to it that these are incorporated into the build so that they will replace the originals.
+Overview
+--------
 
-If your build is based on the downloaded GSI and rootfs, installed using the halium-install script, then further adjustment of the build will not be possible. This is because the halium-script does not include any method for injecting overlay files. If, on the other hand, your build is based on Gitlab CI scripts, there is a way to further tweak your port with overlay files. This method is described at the end of this section.
+The UBports root filesystem image provides a set of default configuration files for a number of features such as display scaling, sound, bluetooth and more. These files may not be tailored to the device-specific features of the porting target and may therefore have to be adjusted. Furthermore, it may be also be necessary to add additional configuration files as well as scripts for specific needs. Overlay files provide a solution for replacing existing or adding new files to the file system.
 
-.. _Overlay-steps:
+The way how overlay files are implemented and their limitations vary across build methods and different versions of Ubuntu Touch. Use of the halium-install script to install a build based on the downloaded GSI and root filesystem image precludes the use of overlay files since it does not provide a mechanism for that.
 
-Configuring features with overlay files
----------------------------------------
+In general, there are two methods of implementing overlay files, one is to directly copy them to the destination path potentially overwriting existing files, the other is to place them in a designated base directory from where they are then mounted onto their destination path during the boot process. The former is only possible when doing builds using the GitLab CI scripts. In case of Ubuntu Touch 16.04 it is the only available overlay mechanism. While the ``system.img`` build process allows overwriting files on the built Android system partition it has no means of doing so on the root filesystem. Ubuntu Touch 16.04 does however offer limited support of mount-based overlay files. Starting from Ubuntu Touch 20.04, the implementation of mount-based overlay files has become more powerful in terms of overlaying both files and directories in vendor and Android images regardless of the build method. The use of mount-based overlay files is generally preferable as it allows for delta OTA updates. Both mechanisms will be discussed in detail below before describing how overlay files are included into the build process in full system image builds and builds based on GitLab CI scripts.
 
-For full ``system.img``-based builds, irrespective of Halium version, the method described below applies if the file you need to edit can be found in the /etc directory (or a subdirectory of this) on your device. In other words, the file or files you wish to overlay must actually exist and be located where specified above. You should not attempt to overwrite files located elsewhere using the method described here.
+The implementations and limitations can be summarized as follows:
 
-If your port is based on Gitlab CI scripts, it is actually possible to not only overlay existing files, but also introduce files that were not originally present. The method for Gitlab CI script based builds is detailed at the end of this section. If this is the method you will be using, you should still read both sections to gain a better understanding of how this method actually works.
++---------------------------+-------------------------------------------------+--------------------------------------------------------------------------------+
+| Build method              | Ubuntu Touch 16.04                              | Ubuntu Touch 20.04                                                             |
++===========================+=================================================+================================================================================+
+| full ``system.img`` build | - add/overwrite files below ``/android/system`` | - add/overwrite files below ``/android/system``                                |
+|                           | - overlay existing files on the root filesystem | - overlay existing files on the root filesystem, android and vendor filesystem |
+|                           | - no new files on the root filesystem           | - new files and directories via merged or replaced overlay directories         |
++---------------------------+-------------------------------------------------+--------------------------------------------------------------------------------+
+| GitLab CI-based build     | - add/overwrite files on the root file system   | - add/overwrite files on the root file system (use overlays instead)           |
+|                           |                                                 | - overlay mounts for existing files on the root, android and vendor filesystem |
+|                           |                                                 | - new files and directories via merged or replaced overlay directories         |
++---------------------------+-------------------------------------------------+--------------------------------------------------------------------------------+
 
-Overlay method for full system.img builds
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-In your device directory, create a subdirectory named 'ubuntu'. Collect the files you wish to inject into your build in this directory.
-
-Relevant files are for example (but this list is incomplete):
-    * ``/lib/udev/rules.d/70-android.rules``
-    * ``/etc/ubuntu-touch-session.d/android.conf`` (for display scaling, see below)
-
-These files are then injected by adding a code block to the file ``device.mk`` in your device directory. For the three files above add the following code::
-
-    ### Ubuntu Touch ###
-    PRODUCT_COPY_FILES += \
-        $(LOCAL_PATH)/ubuntu/70-android.rules:system/halium/lib/udev/rules.d/70-android.rules \
-        $(LOCAL_PATH)/ubuntu/android.conf:system/halium/etc/ubuntu-touch-session.d/android.conf
-    ### End Ubuntu Touch ###
-
-The first of these three files, 70-android.rules, is the one you created when bringing up Lomiri (see :ref:`Lomiri`). Copy it to the 'ubuntu' directory of your device source tree, making sure to add the corresponding line to your ``device.mk`` file, as described above.
-
-Explanation:
-
-The string before the colon '$(LOCAL_PATH)/ubuntu/70-android.rules' specifies the path to the source file to be injected. The string after the colon 'system/halium/lib/udev/rules.d/70-android.rules' specifies the target location on your device.
-
-The general steps to follow are thus:
-    1. Copy the file you wish to modify to the 'ubuntu' directory you have created in your device source tree.
-    2. Edit the file as needed.
-    3. Add a line to the PRODUCT_COPY_FILES section of your device.mk file as shown above.
-    4. Rebuild your system.img and reflash together with the ubports rootfs.
-
-.. Note::
-
-    The target paths for the files mentioned above are *not* randomly chosen. You must use the specified paths.
-
-.. Note::
-
-    When you specify target path 'system/halium/etc/myfilename' your file 'myfilename' will end up in the '/etc' directory of your device (i.e. without the leading 'system/halium')
-
-.. _Rebuild-system.img:
-
-Rebuild system.img
-""""""""""""""""""
-
-For Halium-7.1 ports and Halium-9.0 ports using a device specific system.img in place of the GSI, the system.img now needs to be rebuilt.
-
-When you have made the adjustments you need and prepared your source as described above, rebuild the system image: ``mka systemimage``. 
-
-When rebuilding the system image after small changes like these, you need not ``mka clean`` first. However, changes to PRODUCT_PROPERTY_OVERRIDES might not get detected by the build system. To ensure this, go to the directory ``BUILDDIR/out/target/product/CODENAME/system`` and delete the file ``build.prop`` before rebuilding.
-
-Overlay method for Gitlab CI script-based builds
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Builds in this category can also be adapted to a particular device using overlay files, and when building by this method (see :ref:`Gitlab-CI`) it is possible not only to replace existing files, but also to introduce new ones.
+How mount-based overlay files work
+----------------------------------
 
 Ubuntu Touch 16.04
-""""""""""""""""""
+^^^^^^^^^^^^^^^^^^
 
-Ubuntu Touch 16.04 only allows replacing or introducing individual files on the Ubuntu Touch root filesystem. All of those overlay files need to be placed in the GitLab repository replicating their paths relative to the directory ``overlay/system`` before running the Gitlab CI scripts according to `the instructions included <https://gitlab.com/ubports/community-ports/android9/xiaomi-redmi-note-7-pro/xiaomi-violet/-/blob/master/README.md>`_.
+Ubuntu Touch 16.04 only offers mount-based overlay files in case of full ``system.img``-based builds with the limitation that the overlayed files must actually exist on the root filesystem partition, adding new files is not possible.
 
-For example, in order to introduce the udev rules file ``70-android.rules`` created in the last step in  ``/lib/udev/rules.d/`` on the system it needs to be placed in the directory ``overlay/system/halium/lib/udev/rules.d/`` in the repository.  The build scripts will include it in the build and the overlay files will be bind-mounted onto their final locations during the boot process.
+Overlay files need to be placed on the android system partition below the designated base directory which is mounted at ``/android/system/halium`` on the device. The directory tree with overlay files below that base directory mirrors the structure of the root filesystem, that is the destination path of an overlay file on the root filesystem is derived from its location relative to the base directory. For example, in order to overlay the udev rules file ``/lib/udev/rules.d/70-android.rules`` created in the last step it needs to exist in the directory ``/android/system/halium/lib/udev/rules.d/``. The specifics on how an overlay file can be placed there by the build system will be described below.
 
 Ubuntu Touch 20.04 and later
-""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Ubuntu Touch 20.04 and later provide a much more flexible overlay mechanism.  It not only allows overlaying individual files but also replacing or merging existing directories.  Furthermore, it allows overlaying files and/or directories not only in the Ubuntu Touch root filesystem but also in vendor and Android images.
+Ubuntu Touch 20.04 and later provide a much more flexible implementation which is available both to full ``system.img``-based builds as well as GitLab CI script-based builds. It not only allows overlaying individual files but also replacing or merging existing directories without actually modifying the underlying filesystem.  Furthermore, it is not restricted to the Ubuntu Touch root partition but can also overlay files and directories in vendor and Android partitions.
 
-Overlay files and directories need to be placed in the repository under ``overlay/system``.  Absolute destination paths are derived based on the location of a directory or file relative to the overlay directory tree.  Note that the files or directories under the destination path must neither be writable nor mountpoints themselves.  The overlay directory tree will be traversed in depth-first order during boot according to the following rules:
+Depending on the build method the designated base directory is either ``/opt/halium-overlay`` or ``/android/system/halium`` on the device. The directory tree below the base directory mirrors the root filesystem and destination paths are derived based on the relative location of a directory or file to the base directory.  Note that the files or directories under the destination path must neither be writable nor mount points themselves.  The overlay directory tree will be traversed in depth-first order during boot according to the following rules:
 
 - If a subdirectory contains a special file named ``.halium-override-dir`` that directory will replace the destination directory tree, i.e. the contents of the underlying directory and its descendants will no longer be accessible.
 
-- In case a special file named ``.halium-overlay-dir`` exist in a subdirectory, it will be merged with with the destination directory.  Any file in the underlying directory or descendants thereof remain accessible if no file with the same destination path exists in the overlaying directory tree.  Files and whole directories which only exist in the overlay are made accessible in their respective destination paths.  This is implemented using the overlayfs filesystem (see the `overlayfs documentation <https://www.kernel.org/doc/html/latest/filesystems/overlayfs.html>`_ for the technical details).
+- If a subdirectory contains a special file named ``.halium-overlay-dir`` it will be merged with with the destination directory.  Any file in the underlying directory or descendants thereof remain accessible if no file with the same destination path exists in the overlaying directory tree.  Files and whole directories which only exist in the overlay are made accessible in their respective destination paths.  This is implemented using the overlayfs filesystem (see the `overlayfs documentation <https://www.kernel.org/doc/html/latest/filesystems/overlayfs.html>`_ for the technical details).
 
 - Files in directories containing none of the above special files are bind-mounted over files with an absolute path derived by stripping the above prefix. Subdirectories will be further traversed and evaluated according to the outlined rules.
+
+The specifics on how an overlay file or directory can be placed there depends on the used build system and will be described below.
 
 Example
 """""""
@@ -113,17 +75,15 @@ Contents of the underlying filesystem image::
 
     /etc
     ├── foo
-    │   ├── .halium-overlay-dir
     │   ├── conf.d
     │   │   ├── 10-global.conf
     │   │   ├── 20-system.conf
     │   │   └── 90-local.conf
     │   └── foo.conf
     ├── bar
-    │   ├── .halium-override-dir
     │   ├── bar.conf
     │   └── baz.conf
-    └── quuxrc
+    └── bazrc
 
 The resulting combined filesystem the looks as follows::
 
@@ -139,6 +99,54 @@ The resulting combined filesystem the looks as follows::
     ├── bar (replaced)
     │   ├── .halium-override-dir
     │   └── bar.conf
-    └── quuxrc (replaced)
+    └── bazrc (replaced)
 
-The directory ``/etc/foo`` has been merged, whereas the ``/etc/bar`` directory and the file ``/etc/quuxrc`` have been replaced.
+The directory ``/etc/foo`` has been merged, whereas the ``/etc/bar`` directory and the file ``/etc/bazrc`` have been replaced.
+
+.. _Overlay-steps:
+
+Overlay files in full system.img builds
+---------------------------------------
+
+In the case of full ``system.img``-based builds all supported Halium versions allow for copying overlay files to the Android system filesystem image during the build process by adding entries to the ``PRODUCT_COPY_FILES`` macro. Each entry consists of the source and destination path of a file, seperated by a “``:``”. As a matter of convention, all overlay files should be placed in a directory ``ubuntu`` below the root path of the repository. This directory can be referred to as ``$(LOCAL_PATH)/ubuntu``. The destination directory should be specified relative to its default mountpoint ``/android/system`` referred to as ``$(TARGET_COPY_OUT_SYSTEM)``.
+
+It is thus only possible to add or overwrite files below ``/android/system``. In order to make use of mount-based overlay files they should be placed below the designated base directory ``/android/system/halium`` as described above. Due to the limitations in Ubuntu 16.04 it is only possible to add new files via overlay or override directories available in Ubuntu 20.04 or later.
+
+Example
+^^^^^^^
+
+Typically at least the file ``/lib/udev/rules.d/70-android.rules`` created when bringing up Lomiri (see :ref:`Lomiri`) and the file ``/etc/ubuntu-touch-session.d/android.conf`` for configuring display scaling need to be added via overlay files. The bind mount mechanism of both Ubuntu Touch 16.04 and 20.04 requires that the files are placed below the designated base directory ``/android/system/halium``, that is at ``/android/system/halium/lib/udev/rules.d/70-android.rules`` and ``/android/system/halium/etc/ubuntu-touch-session.d/android.conf``
+
+Both ``70-android.rules`` and ``android.conf`` should be placed in the subdirectory ``ubuntu`` of the repository and the following lines need to be added to ``device.mk`` in order to copy them onto the generated image::
+
+    ### Ubuntu Touch ###
+    PRODUCT_COPY_FILES += \
+        $(LOCAL_PATH)/ubuntu/70-android.rules:$(TARGET_COPY_OUT_SYSTEM)/halium/lib/udev/rules.d/70-android.rules \
+        $(LOCAL_PATH)/ubuntu/android.conf:$(TARGET_COPY_OUT_SYSTEM)/halium/etc/ubuntu-touch-session.d/android.conf
+    ### End Ubuntu Touch ###
+
+.. _Rebuild-system.img:
+
+Rebuilding system.img
+^^^^^^^^^^^^^^^^^^^^^
+
+After any changes the ``system.img`` needs to be rebuilt using ``mka clean`` and ``mka systemimage``. When repeatedly rebuilding the system image after small changes, it is possible to do incremental builds without issuing a ``mka clean`` first. However, changes to PRODUCT_PROPERTY_OVERRIDES might not get detected by the build system. In that case the file ``build.prop`` in the directory ``BUILDDIR/out/target/product/CODENAME/system`` should be removed manually before rebuilding.
+
+After a successful build, the resulting ``system.img`` must reflashed together with the UBports root filesystem. On boot files and – in case of Ubuntu Touch 20.04 or later – marked directories in ``/android/system/halium`` will be mounted onto their final locations which are derived from their path relative to the designated base directory.
+
+Overlay files in Gitlab CI script-based builds
+----------------------------------------------
+
+When using Gitlab CI script-based builds (see :ref:`Gitlab-CI`) overlay files and directories have to be placed in in the repository below ``overlay/system`` in a directory tree mirroring the structure of the root filesystem. Note that any overlay file placed in that directory tree will overwrite an existing file on the root filesystem. While Ubuntu Touch 16.04 only allows overlaying files by overwriting them, in case of Ubuntu Touch 20.04 or later versions the mount-based overlay files should be used instead. Thus overlay files and directories should be placed in a directory tree below ``overlay/system/opt/halium-overlay`` in the repository rather than directly below ``overlay/system``. 
+
+Example
+^^^^^^^
+
+Following the above example on Ubuntu Touch 20.04, adding the overlay files ``/lib/udev/rules.d/70-android.rules`` and ``/etc/ubuntu-touch-session.d/android.conf`` requires them to end up below ``/opt/halium-overlay`` on the resulting filesystem, that is as ``/opt/halium-overlay/lib/udev/rules.d/70-android.rules`` and ``/opt/halium-overlay/etc/ubuntu-touch-session.d/android.conf``. This is achieved by placing them at ``overlay/system/opt/halium-overlay/lib/udev/rules.d/70-android.rules`` and ``overlay/system/opt/halium-overlay/etc/ubuntu-touch-session.d/android.conf`` in the repository.
+
+In case of Ubuntu Touch 16.04 the files on the root filesystem need to be overwritten due to the lack of mount-based overlay files and must thus be placed at ``overlay/system/lib/udev/rules.d/70-android.rules`` and ``overlay/system/etc/ubuntu-touch-session.d/android.conf`` in the repository.
+
+Building on GitLab CI
+^^^^^^^^^^^^^^^^^^^^^
+
+After adding or modifying overlay files the Gitlab CI scripts need to be run according to `the instructions included <https://gitlab.com/ubports/community-ports/android9/xiaomi-redmi-note-7-pro/xiaomi-violet/-/blob/master/README.md>`_. On boot files and – in case of Ubuntu Touch 20.04 or later – marked directories in ``/opt/halium-overlay`` will be mounted onto their final locations which are derived from their path relative to the designated base directory.

--- a/porting/configure_test_fix/Overlay.rst
+++ b/porting/configure_test_fix/Overlay.rst
@@ -33,7 +33,7 @@ These files are then injected by adding a code block to the file ``device.mk`` i
         $(LOCAL_PATH)/ubuntu/android.conf:system/halium/etc/ubuntu-touch-session.d/android.conf
     ### End Ubuntu Touch ###
 
-The first of these three files, 70-android.rules, is the one you created when bringing up Lomiri. You can extract this file from the device using ``adb pull`` or ``scp`` and copy it to the 'ubuntu' directory of your device source tree, making sure to add the corresponding line to your ``device.mk`` file, as described above.
+The first of these three files, 70-android.rules, is the one you created when bringing up Lomiri (see :ref:`Lomiri`). Copy it to the 'ubuntu' directory of your device source tree, making sure to add the corresponding line to your ``device.mk`` file, as described above.
 
 Explanation:
 

--- a/porting/configure_test_fix/Overlay.rst
+++ b/porting/configure_test_fix/Overlay.rst
@@ -69,14 +69,76 @@ Overlay method for Gitlab CI script-based builds
 
 Builds in this category can also be adapted to a particular device using overlay files, and when building by this method (see :ref:`Gitlab-CI`) it is possible not only to replace existing files, but also to introduce new ones.
 
-When you have prepared the files to replace or introduce, and determined the exact locations where they need to go on your device, these locations need to be replicated under the directory ``overlay/system/`` before running the Gitlab CI scripts according to `the instructions included. <https://gitlab.com/ubports/community-ports/android9/xiaomi-redmi-note-7-pro/xiaomi-violet/-/blob/master/README.md>`_
+Ubuntu Touch 16.04
+""""""""""""""""""
 
-For example:
-""""""""""""
+Ubuntu Touch 16.04 only allows replacing or introducing individual files on the Ubuntu Touch root filesystem. All of those overlay files need to be placed in the GitLab repository replicating their paths relative to the directory ``overlay/system`` before running the Gitlab CI scripts according to `the instructions included <https://gitlab.com/ubports/community-ports/android9/xiaomi-redmi-note-7-pro/xiaomi-violet/-/blob/master/README.md>`_.
 
-The udev rules file ``70-android.rules`` needs to go into ``system/halium/lib/udev/rules.d/``. This is accomplished by first creating the directory in the Gitlab scripts build tree. Standing in the root of this tree, first create the directory and then copy the file to this location::
+For example, in order to introduce the udev rules file ``70-android.rules`` created in the last step in  ``/lib/udev/rules.d/`` on the system it needs to be placed in the directory ``overlay/system/halium/lib/udev/rules.d/`` in the repository.  The build scripts will include it in the build and the overlay files will be bind-mounted onto their final locations during the boot process.
 
-    mkdir /halium/lib/udev/rules.d
-    cp <path-to-70-android.rules> /halium/lib/udev/rules.d/70-android.rules
+Ubuntu Touch 20.04 and later
+""""""""""""""""""""""""""""
 
-Now run the build scripts and the file will get incorporated into your build. Flash the files as per `the instructions. <https://gitlab.com/ubports/community-ports/android9/xiaomi-redmi-note-7-pro/xiaomi-violet/-/blob/master/README.md>`_
+Ubuntu Touch 20.04 and later provide a much more flexible overlay mechanism.  It not only allows overlaying individual files but also replacing or merging existing directories.  Furthermore, it allows overlaying files and/or directories not only in the Ubuntu Touch root filesystem but also in vendor and Android images.
+
+Overlay files and directories need to be placed in the repository under ``overlay/system``.  Absolute destination paths are derived based on the location of a directory or file relative to the overlay directory tree.  Note that the files or directories under the destination path must neither be writable nor mountpoints themselves.  The overlay directory tree will be traversed in depth-first order during boot according to the following rules:
+
+- If a subdirectory contains a special file named ``.halium-override-dir`` that directory will replace the destination directory tree, i.e. the contents of the underlying directory and its descendants will no longer be accessible.
+
+- In case a special file named ``.halium-overlay-dir`` exist in a subdirectory, it will be merged with with the destination directory.  Any file in the underlying directory or descendants thereof remain accessible if no file with the same destination path exists in the overlaying directory tree.  Files and whole directories which only exist in the overlay are made accessible in their respective destination paths.  This is implemented using the overlayfs filesystem (see the `overlayfs documentation <https://www.kernel.org/doc/html/latest/filesystems/overlayfs.html>`_ for the technical details).
+
+- Files in directories containing none of the above special files are bind-mounted over files with an absolute path derived by stripping the above prefix. Subdirectories will be further traversed and evaluated according to the outlined rules.
+
+Example
+"""""""
+
+Contents of ``overlay/system/halium``::
+
+    overlay
+    └── system
+        └── halium
+            └── etc
+                ├── foo
+                │   ├── .halium-overlay-dir
+                │   ├── conf.d
+                │   │   ├── 50-drivers.conf
+                │   │   └── 90-local.conf
+                │   └── foo.conf
+                ├── bar
+                │   ├── .halium-override-dir
+                │   └── bar.conf
+                └── bazrc
+
+Contents of the underlying filesystem image::
+
+    /etc
+    ├── foo
+    │   ├── .halium-overlay-dir
+    │   ├── conf.d
+    │   │   ├── 10-global.conf
+    │   │   ├── 20-system.conf
+    │   │   └── 90-local.conf
+    │   └── foo.conf
+    ├── bar
+    │   ├── .halium-override-dir
+    │   ├── bar.conf
+    │   └── baz.conf
+    └── quuxrc
+
+The resulting combined filesystem the looks as follows::
+
+    /etc
+    ├── foo
+    │   ├── .halium-overlay-dir
+    │   ├── conf.d
+    │   │   ├── 10-global.conf
+    │   │   ├── 20-system.conf
+    │   │   ├── 50-drivers.conf (added)
+    │   │   └── 90-local.conf   (replaced)
+    │   └── foo.conf (replaced)
+    ├── bar (replaced)
+    │   ├── .halium-override-dir
+    │   └── bar.conf
+    └── quuxrc (replaced)
+
+The directory ``/etc/foo`` has been merged, whereas the ``/etc/bar`` directory and the file ``/etc/quuxrc`` have been replaced.


### PR DESCRIPTION
This is a complete rewrite of the section on overlay files. It first provides a
separate explanation on how the different overlay mechanisms work and how they
differ between 16.04 and 20.04. After that it explains on how to make use of
that mechanism using the different build methods with an example each.