### PR TITLE
Fix build for master

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -65,7 +65,7 @@ release = u''
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>2
+sphinx==4.5.0
 furo==2021.6.24b37
 sphinx-intl
 sphinxext-rediraffe


### PR DESCRIPTION
CI's sphinx version auto update to 5.0.1, which has changed behavior regarding language configuration.

Currently it is set to `None`, however this will be treated as error and the CI builds error out:
```
+ python3 -m sphinx -Wab html . _build/html/
Running Sphinx v5.0.1

Warning, treated as error:
Invalid configuration value found: 'language = None'. Update your configuration to a valid langauge code. Falling back to 'en' (English).
```

Set it to `en` to fix this error.

Also to prevent unexpected breakage in future by behavior changes of sphinx, fix the version to the latest 4.x version at the time of writing: `4.5.0`.