### PR TITLE
porting: configuring: repowerd: add new config option for DT2W

### DIFF
--- a/porting/configure_test_fix/device_info/Repowerd.rst
+++ b/porting/configure_test_fix/device_info/Repowerd.rst
@@ -7,25 +7,34 @@ Overview of all repowerd keys::
 
     <devicename>:
       BacklightSysfsPath: </path/to/the/device>
+      DoubleTapToWake:
+        - </path/to/node>|<enable>|<disable>
+        - ...
 
 Device quirks
 -------------
 
-==================  =============================  =========
-Key                 Description                    Value(s)
-==================  =============================  =========
-BacklightSysfsPath  File path to backlight device  File path
-==================  =============================  =========
+==================  ===============================  ========================================================
+Key                 Description                      Value(s)
+==================  ===============================  ========================================================
+BacklightSysfsPath  File path to backlight device    File path
+DoubleTapToWake     Configuration for toggling DT2W  List of formatted strings: ``<path>|<enable>|<disable>``
+==================  ===============================  ========================================================
 
 Examples
 --------
 
-Device `sample` using with:
+Device `sample` using:
 
 - Custom backlight sysfs path to disable autodetection of the path controlling the backlight
+- Double Tap to Wake (DT2W) configuration to allow double tapping to wake the device, specifing two potential paths
+    - It is allowed to specify multiple entries, invalid or non-existant paths will be removed
 
 Config file::
 
     $ cat /etc/deviceinfo/devices/sample.yaml
     sample:
       BacklightSysfsPath: /sys/class/backlight/panel0-backlight
+      DoubleTapToWake:
+        - /proc/touchpanel/double_tap_enable|1|0
+        - /sys/devices/platform/soc/a84000.i2c/i2c-2/2-0020/input/input1/wake_gesture|on|off


### PR DESCRIPTION
Double Tap to Wake support has landed in UT.

Settings: https://gitlab.com/ubports/development/core/lomiri-system-settings/-/merge_requests/335
Repowerd: https://gitlab.com/ubports/development/core/repowerd/-/merge_requests/53
Sample device configuration: https://gitlab.com/ubports/porting/community-ports/android10/shift/shift-axolotl/-/merge_requests/4