### PR TITLE
Move the reboot step after enabling developer mode

### DIFF
--- a/userguide/advanceduse/adb.rst
+++ b/userguide/advanceduse/adb.rst
@@ -28,8 +28,8 @@ Enable developer mode
 
 Next, you'll need to turn on Developer Mode.
 
-#. Reboot your device
 #. Place your device into developer mode (Settings - About - Developer Mode - check the box to turn it on)
+#. Reboot your device
 #. Plug the device into a computer with ADB installed
 #. Open a terminal and run ``adb devices``.
 


### PR DESCRIPTION
The device has to be rebooted after developer mode is enabled, rebooting it earlier doesn't do anything.