### PR TITLE
Be explicit about Cache directory purpose

### DIFF
--- a/appdev/guides/writeable-dirs.rst
+++ b/appdev/guides/writeable-dirs.rst
@@ -19,6 +19,9 @@ Path: ``/home/phablet/.cache/<fullappname>/``
 
 This is the place to cache data for later use. The cache is also used by the Content Hub. Files that have been shared with the music app for example can be found in ``/home/phablet/.cache/com.ubuntu.music/HubIncoming/``.
 
+.. note::
+    Data in the cache directory should be treated as temporary and the app should still function normally if this directory is cleared - clearing cache is commonly done to recover some space on the device. Don't store user account info here :)
+
 App data
 ^^^^^^^^
 Path: ``/home/phablet/.local/share/<fullappname>/``


### PR DESCRIPTION
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
> There is a single base directory relative to which user-specific **non-essential (cached) data** should be written. This directory is defined by the environment variable $XDG_CACHE_HOME.

https://doc.qt.io/qt-5/qstandardpaths.html#StandardLocation-enum
> QStandardPaths::CacheLocation
> Returns a directory location where user-specific **non-essential (cached) data** should be written. [...]

[Android StackExchange: What is the difference between application cache and data?](https://android.stackexchange.com/a/108975/79058)

How users think about cache:
https://www.androidpolice.com/clear-app-cache-data-android/
> What is a cache?
> Caching lets applications like browsers, games, and streaming services store **temporary files** to reduce load times and make your overall experience faster. YouTube, Spotify, Google News, and other apps save information as cache data. This can be video thumbnails, search history, or snippets of video used to minimize user input.

(emphasis mine)
