### PR TITLE
porting: configuring: DeviceInfo: add HfdService section

### DIFF
--- a/porting/configure_test_fix/device_info/HfdService.rst
+++ b/porting/configure_test_fix/device_info/HfdService.rst
@@ -1,0 +1,31 @@
+.. _DeviceInfo_HfdService:
+
+hfd-service
+===========
+
+Overview of all hfd-service keys::
+
+    <devicename>:
+      VibrateDurationExtraMs: <any integer value>
+
+Device quirks
+-------------
+
+======================  =============================================  ==================
+Key                     Description                                    Value(s)
+======================  =============================================  ==================
+VibrateDurationExtraMs  Milliseconds to extend all vibration calls by  Any integer number
+======================  =============================================  ==================
+
+Examples
+--------
+
+Device ``sample`` using:
+
+- Extend vibrations by 50 milliseconds to feel the on-screen keyboard haptics on devices with simpler on/off vibration motors
+
+Config file::
+
+    $ cat /etc/deviceinfo/devices/sample.yaml
+    sample:
+      VibrateDurationExtraMs: 50

--- a/porting/configure_test_fix/device_info/index.rst
+++ b/porting/configure_test_fix/device_info/index.rst
@@ -60,3 +60,4 @@ Other keys are documented in the component specific subpages.
 
    Mir
    Repowerd
+   HfdService


### PR DESCRIPTION
Documents `hfd-service`'s `VibrateDurationExtraMs` deviceinfo key.

See https://gitlab.com/ubports/development/core/hfd-service/-/merge_requests/9.