### PR TITLE
Add python2 to build dependencies

### DIFF
--- a/porting/introduction/Setting_up.rst
+++ b/porting/introduction/Setting_up.rst
@@ -54,7 +54,7 @@ Install the required dependencies::
     libgl1-mesa-dev g++-multilib mingw-w64-i686-dev tofrodos \
     python3-markdown libxml2-utils xsltproc zlib1g-dev:i386 schedtool \
     liblz4-tool bc lzop imagemagick libncurses5 rsync \
-    python-is-python3
+    python-is-python3 python2
 
 Create a directory named 'bin' in your home directory, and include it in your path::
 


### PR DESCRIPTION
There are build scripts that explicitly call `python2`. Therefore it needs to be installed.