### PR TITLE
Depreciate Anbox

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -48,7 +48,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'UBports'
-copyright = u'2019-2022, The UBports project (Creative Commons BY-SA 4.0)'
+copyright = u'2019-2023, The UBports project (Creative Commons BY-SA 4.0)'
 author = u'UBports project'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/userguide/dailyuse/anbox.rst
+++ b/userguide/dailyuse/anbox.rst
@@ -1,7 +1,7 @@
 Android apps
 ========================
 
-`Anbox <https://anbox.io>`_ is a minimal Android container and compatibility layer to run Android apps on GNU/Linux operating systems such as Ubuntu Touch.
+`Anbox <https://anbox.io>`_ is a minimal Android container and compatibility layer to run Android apps on GNU/Linux operating systems such as Ubuntu Touch. **Anbox has been depreceated in favour of Waydroid.**
 
 .. note::
     "Computer" refers to another device you connect your Ubuntu Touch device to (via USB here).


### PR DESCRIPTION
Adds a depreciation notice to the Anbox .rst file.

I know the other PR redirects anbox to a in-progress Waydroid doc, however it may still be a good idea to keep the Anbox documentation files, as there may be edge cases (on some older UT devices?) where keeping docs up for Anbox may be a good idea.