### PR TITLE
Make build script compatible with newer Ubuntu that disallows direct usage of pip3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,8 +21,7 @@ if [ -d "$UBPORTSDOCSENV" ]; then
 else
   echo -e "${YELLOW}Build environment not found in \"$UBPORTSDOCSENV\" ... creating it.${PLAIN}"
   echo -e "${YELLOW}Installing pip and virtualenv (using sudo).${PLAIN}"
-  sudo apt install python3-pip
-  sudo -H pip3 install virtualenv
+  sudo apt install python3-pip python3-virtualenv
   echo -e "${YELLOW}Creating a virtual environment in \"$UBPORTSDOCSENV\".${PLAIN}"
   virtualenv $UBPORTSDOCSENV
   source $UBPORTSDOCSENV/bin/activate


### PR DESCRIPTION
New Ubuntu versions like Ubuntu 23.04 disallow the direct invocation of `pip3`. This PR changes the build script to install virtualenv via `apt` instead of `pip3` to fix that. The subsequent `pip3` call is executed within the virtual env and therefore doesn't impose any issue.