### PR TITLE
Update to the latest version of Sphinx

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,8 @@ pipeline {
     stages {
         stage("Install dependencies") {
             steps {
+                sh 'python --version'
+                sh 'pip --version'
                 // TODO: the `--quiet` is to workaround some Docker/Jenkins bugs/misconfigurations, this should be removed at some point
                 sh 'pip install --quiet --no-cache-dir --user --upgrade -r requirements.txt'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image "python:3.7"
+            image "python:3.12"
         }
     }
     options {
@@ -13,7 +13,8 @@ pipeline {
     stages {
         stage("Install dependencies") {
             steps {
-                sh 'pip install --no-cache-dir --user --upgrade -r requirements.txt'
+                // TODO: the `--quiet` is to workaround some Docker/Jenkins bugs/misconfigurations, this should be removed at some point
+                sh 'pip install --quiet --no-cache-dir --user --upgrade -r requirements.txt'
             }
         }
         stage("Build docs"){

--- a/index.rst
+++ b/index.rst
@@ -1,3 +1,5 @@
+:hide-toc:
+
 Welcome to the UBports documentation!
 =====================================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==4.5.0
-furo==2021.6.24b37
+sphinx==7.2.6
+furo==2024.1.29
 sphinx-intl
 sphinxext-rediraffe


### PR DESCRIPTION
I have not been able to find any (bad) differences between the current live version and when using the latest version of Sphinx/Furo. As far as I can tell, the stability policy from Furo ([available here](https://pradyunsg.me/furo/stability/)), keeping both at simply the latest version available should be safe.

The ToC change is needed for the index page because it seems to generate an empty Contents list for some reason. Given the fact that the Sphinx 4.5.0 generated page has no contents bar here, hiding it here seems like the correct call.