### PR TITLE
drop the links to the halium group

### DIFF
--- a/porting/introduction/Intro.rst
+++ b/porting/introduction/Intro.rst
@@ -119,10 +119,8 @@ Getting community help
 
 When you run into trouble, and you will, refer to one or more of the sources below:
 
-* `Telegram: @halium <https://t.me/halium>`_
 * `Telegram: @ubports_porting <https://t.me/ubports_porting>`_
 * `The UBports Forum <https://forums.ubports.com/category/33/porting>`_
-* Matrix: #halium:matrix.org
 
 .. _General-advice:
 


### PR DESCRIPTION
@notkit has said that we should direct people to only the porting group: https://t.me/ubports_porting/194751 (well he said that the halium group should be dropped, but same difference imo). The idea being that we should recommend the standalone Kernel Method now.

To that end i have dropped the halium group links from the documentation, but i am unsure how to structure it in such a way that we indeed promote the standalone kernel method

considering we now have a separate branch for xenial documentation and focal devices are primarily focal devices— maybe we should just drop the pre halium 9 documentation? i'm also open for less radical ideas tho xd