### PR TITLE
Update tethering docs

### DIFF
--- a/userguide/advanceduse/reverse-tethering.rst
+++ b/userguide/advanceduse/reverse-tethering.rst
@@ -9,17 +9,17 @@ Steps to Set Up Reverse Tethering
 
 #. Prepare your device (Ubuntu Touch) and your computer:
 
-   - Connect your computer to the internet.
-   - Attach your device to your computer via USB.
+   - Connect your *computer* to the internet.
+   - Attach your *device* to your *computer* via USB.
+   - Turn off Wifi and Data on your *device*
 
-#. On the *device*:
+#. Run the following commands on your *device*:
 
-   - Turn off Wifi and Data to avoid the gateways from clashing
    - Set your device usb in tethering mode: ``gdbus call --system --dest com.meego.usb_moded --object-path /com/meego/usb_moded --method com.meego.usb_moded.set_mode rndis_adb``
    - Bring your tethering connection down: ``sudo nmcli connection down tethering``
    - Modify your tethering connection: ``sudo nmcli connection modify tethering ipv4.method auto``
 
-#. On your *computer*: 
+#. Run the following commands on your *computer*: 
 
    - Get your interface name: ``ip route show to default via 10.42.0.1``
      ::
@@ -37,16 +37,16 @@ Steps to Set Up Reverse Tethering
    - Change the ipv4 method to ``shared``: ``nmcli connection modify "Wired connection 2" ipv4.method shared``
    - Bring the connection back up: ``nmcli connection up "Wired connection 2"``
 
-#. On the *device*:
+#. Finally run the following command on your *device*:
 
    - Bring your tethering connection back up: ``sudo nmcli connection up tethering``
-   - Open Morph Browser and test your internet connection!
 
+You should now have a working internet connection on your *device*!
 
 Troubleshooting
 ---------------
 
-If the above steps don't give you working internet connection on your phone the try these steps on your *computer*:
+If the above steps don't give you working internet connection on your *device* the try these steps on your *computer*:
 
    - Turn on IP forwarding: ``echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward``
    - Apply Forwarding iptables Rule: ``sudo iptables -P FORWARD ACCEPT``

--- a/userguide/advanceduse/reverse-tethering.rst
+++ b/userguide/advanceduse/reverse-tethering.rst
@@ -15,55 +15,49 @@ Steps
 #. On the *device*:
 
    - Run: ``gdbus call --system --dest com.meego.usb_moded --object-path /com/meego/usb_moded --method com.meego.usb_moded.set_mode rndis_adb``
+   - Turn off Wifi and Data to avoid the gateways from clashing
+   - Bring your tethering connection down: Run ``nmcli connection down tethering``
+   - Modify your tethering connection: Run ``nmcli connection modify tethering ipv4.method auto``
 
 #. On your *computer*: 
 
    - Get your RNDIS IP address:
 
      - Run: ``ip a``
-     - Look for an interface named ``usb0`` in the output:
-
+     - Look for an interface with an ip address that looks like `10.42.0.x` in the output:
        ::
 
-         5: usb0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 1000
-            link/ether 12:34:56:ab:cd:ef brd ff:ff:ff:ff:ff:ff
-            inet 10.42.0.149/24 brd 10.42.0.255 scope global noprefixroute usb0
-              valid_lft forever preferred_lft forever
+         5: enx122626d0fe26: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
+            link/ether 12:26:26:d0:fe:26 brd ff:ff:ff:ff:ff:ff
+            inet 10.42.0.98/24 brd 10.42.0.255 scope global dynamic noprefixroute enx122626d0fe26
+               valid_lft 3496sec preferred_lft 3496sec
+            inet6 fe80::5878:3a14:c380:f458/64 scope link noprefixroute
+               valid_lft forever preferred_lft forever
 
-       - Your IP is: ``10.42.0.149``
+       - Your interface name is: ``enx122626d0fe26``
+       - Run: ``nmcli connection show``
+       - Look for a connection with the interface name you found in the output:
+         ::
+           NAME                UUID                                  TYPE      DEVICE
+           Wired connection 1  a2ab069f-ff15-398f-ac42-94c80cddeecb  ethernet  enp0s31f6
+           Wired connection 2  711ca903-d557-3f61-a8f6-6a2bb0aa037c  ethernet  enx122626d0fe26
+           lo                  a0692fbf-1219-4629-9eec-6c93d8462d5f  loopback  lo
+           FP4                 412164a9-77d0-4d07-937f-e641de068309  wifi      --
+       - Your connection name is ``Wired connection 2``
+       - Run: ``nmcli connection down Wired\ connection\ 2``
+       - Run: ``nmcli connection modify Wired\ connection\ 2 ipv4.method shared``
+       - Run: ``nmcli connection up Wired\ connection\ 2``
 
 #. On the *device*:
 
-   - Turn off Wifi and Data to avoid the gateways from clashing
-   - Get your RNDIS interface: Run ``ip a``
-
-     ::
-
-       31: usb0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
-           link/ether 12:34:56:ab:cd:ef brd ff:ff:ff:ff:ff:ff
-           inet 10.42.0.1/8 brd 10.255.255.255 scope global rndis0
-             valid_lft forever preferred_lft forever
-
-     - Your interface is: ``usb0``
-
-   - Add your computer as default gateway: ``sudo route add default gw 10.42.0.149``
-   - Add a nameserver of your choice: ``echo "nameserver 1.1.1.1" | sudo tee -a /etc/resolv.conf``
+   - Bring your tethering connection back up: Run ``nmcli connection up tethering``
    - Open Morph Browser and test your internet connection!
 
 #. If it's not working yet, on your *computer*:
 
    - Turn on IP forwarding: ``echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward``
    - Apply Forwarding iptables Rule: ``sudo iptables -P FORWARD ACCEPT``
-   - Apply NAT rule: ``sudo iptables -t nat -A POSTROUTING -s 10.42.0.0/24 -j MASQUERADE``
 
-   - NOTE: These steps are usually performed automatically by the NetworkManager on Ubuntu 22.04.
-
-Known Issues
-------------
-
-- The Updates page in the System Settings displays: ``Connect to the Internet to check for updates.``
-- After a while Teleports looses its internet connection and must be restarted.
-  
 References
 ----------
 

--- a/userguide/advanceduse/reverse-tethering.rst
+++ b/userguide/advanceduse/reverse-tethering.rst
@@ -21,32 +21,37 @@ Steps
 
 #. On your *computer*: 
 
-   - Get your RNDIS IP address:
+   - Get your interface name: Run ``ip route show to default via 10.42.0.1``
+     ::
 
-     - Run: ``ip a``
-     - Look for an interface with an ip address that looks like `10.42.0.x` in the output:
-       ::
+       default dev enx122626d0fe26 proto dhcp src 10.42.0.118 metric 101
 
-         5: enx122626d0fe26: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
-            link/ether 12:26:26:d0:fe:26 brd ff:ff:ff:ff:ff:ff
-            inet 10.42.0.98/24 brd 10.42.0.255 scope global dynamic noprefixroute enx122626d0fe26
-               valid_lft 3496sec preferred_lft 3496sec
-            inet6 fe80::5878:3a14:c380:f458/64 scope link noprefixroute
-               valid_lft forever preferred_lft forever
+   - Your interface name is: ``enx122626d0fe26``
+   - Get your connection name: Run ``nmcli device show enx122626d0fe26``
+   - Look for a connection with the interface name you found in the output:
+     ::
 
-       - Your interface name is: ``enx122626d0fe26``
-       - Run: ``nmcli connection show``
-       - Look for a connection with the interface name you found in the output:
-         ::
-           NAME                UUID                                  TYPE      DEVICE
-           Wired connection 1  a2ab069f-ff15-398f-ac42-94c80cddeecb  ethernet  enp0s31f6
-           Wired connection 2  711ca903-d557-3f61-a8f6-6a2bb0aa037c  ethernet  enx122626d0fe26
-           lo                  a0692fbf-1219-4629-9eec-6c93d8462d5f  loopback  lo
-           FP4                 412164a9-77d0-4d07-937f-e641de068309  wifi      --
-       - Your connection name is ``Wired connection 2``
-       - Run: ``nmcli connection down Wired\ connection\ 2``
-       - Run: ``nmcli connection modify Wired\ connection\ 2 ipv4.method shared``
-       - Run: ``nmcli connection up Wired\ connection\ 2``
+       GENERAL.DEVICE:                         enx122626d0fe26
+       GENERAL.TYPE:                           ethernet
+       GENERAL.HWADDR:                         FA:F7:F5:D9:4C:9E
+       GENERAL.MTU:                            1500
+       GENERAL.STATE:                          100 (connected)
+       GENERAL.CONNECTION:                     Wired connection 2
+       GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/12
+       WIRED-PROPERTIES.CARRIER:               on
+       IP4.ADDRESS[1]:                         10.42.0.118/24
+       IP4.GATEWAY:                            10.42.0.1
+       IP4.ROUTE[1]:                           dst = 10.42.0.0/24, nh = 0.0.0.0, mt = 101
+       IP4.ROUTE[2]:                           dst = 0.0.0.0/0, nh = 10.42.0.1, mt = 101
+       IP4.DNS[1]:                             10.42.0.1
+       IP6.ADDRESS[1]:                         fe80::692:2a1:8127:91a1/64
+       IP6.GATEWAY:                            --
+       IP6.ROUTE[1]:                           dst = fe80::/64, nh = ::, mt = 1024
+
+   - Your connection name is ``Wired connection 2``
+   - Bring the connection down: Run ``nmcli connection down Wired\ connection\ 2``
+   - Change the ipv4 method to ``shared``: Run ``nmcli connection modify Wired\ connection\ 2 ipv4.method shared``
+   - Bring the connection back up: Run ``nmcli connection up Wired\ connection\ 2``
 
 #. On the *device*:
 

--- a/userguide/advanceduse/reverse-tethering.rst
+++ b/userguide/advanceduse/reverse-tethering.rst
@@ -4,8 +4,8 @@ Reverse tethering
 This tutorial explains how you get your Ubuntu Touch device online using a USB cable and a computer with internet access.
 This is useful if there is no available Wi-Fi connection or you don't have a data subscription on your device.
 
-Steps
------
+Steps to Set Up Reverse Tethering
+---------------------------------
 
 #. Prepare your device (Ubuntu Touch) and your computer:
 
@@ -14,51 +14,39 @@ Steps
 
 #. On the *device*:
 
-   - Run: ``gdbus call --system --dest com.meego.usb_moded --object-path /com/meego/usb_moded --method com.meego.usb_moded.set_mode rndis_adb``
    - Turn off Wifi and Data to avoid the gateways from clashing
-   - Bring your tethering connection down: Run ``nmcli connection down tethering``
-   - Modify your tethering connection: Run ``nmcli connection modify tethering ipv4.method auto``
+   - Set your device usb in tethering mode: ``gdbus call --system --dest com.meego.usb_moded --object-path /com/meego/usb_moded --method com.meego.usb_moded.set_mode rndis_adb``
+   - Bring your tethering connection down: ``sudo nmcli connection down tethering``
+   - Modify your tethering connection: ``sudo nmcli connection modify tethering ipv4.method auto``
 
 #. On your *computer*: 
 
-   - Get your interface name: Run ``ip route show to default via 10.42.0.1``
+   - Get your interface name: ``ip route show to default via 10.42.0.1``
      ::
 
        default dev enx122626d0fe26 proto dhcp src 10.42.0.118 metric 101
 
    - Your interface name is: ``enx122626d0fe26``
-   - Get your connection name: Run ``nmcli device show enx122626d0fe26``
-   - Look for a connection with the interface name you found in the output:
+   - Get your connection name: ``nmcli --field GENERAL.CONNECTION device show enx122626d0fe26``
      ::
 
-       GENERAL.DEVICE:                         enx122626d0fe26
-       GENERAL.TYPE:                           ethernet
-       GENERAL.HWADDR:                         FA:F7:F5:D9:4C:9E
-       GENERAL.MTU:                            1500
-       GENERAL.STATE:                          100 (connected)
        GENERAL.CONNECTION:                     Wired connection 2
-       GENERAL.CON-PATH:                       /org/freedesktop/NetworkManager/ActiveConnection/12
-       WIRED-PROPERTIES.CARRIER:               on
-       IP4.ADDRESS[1]:                         10.42.0.118/24
-       IP4.GATEWAY:                            10.42.0.1
-       IP4.ROUTE[1]:                           dst = 10.42.0.0/24, nh = 0.0.0.0, mt = 101
-       IP4.ROUTE[2]:                           dst = 0.0.0.0/0, nh = 10.42.0.1, mt = 101
-       IP4.DNS[1]:                             10.42.0.1
-       IP6.ADDRESS[1]:                         fe80::692:2a1:8127:91a1/64
-       IP6.GATEWAY:                            --
-       IP6.ROUTE[1]:                           dst = fe80::/64, nh = ::, mt = 1024
 
    - Your connection name is ``Wired connection 2``
-   - Bring the connection down: Run ``nmcli connection down Wired\ connection\ 2``
-   - Change the ipv4 method to ``shared``: Run ``nmcli connection modify Wired\ connection\ 2 ipv4.method shared``
-   - Bring the connection back up: Run ``nmcli connection up Wired\ connection\ 2``
+   - Bring the connection down: ``nmcli connection down "Wired connection 2"``
+   - Change the ipv4 method to ``shared``: ``nmcli connection modify "Wired connection 2" ipv4.method shared``
+   - Bring the connection back up: ``nmcli connection up "Wired connection 2"``
 
 #. On the *device*:
 
-   - Bring your tethering connection back up: Run ``nmcli connection up tethering``
+   - Bring your tethering connection back up: ``sudo nmcli connection up tethering``
    - Open Morph Browser and test your internet connection!
 
-#. If it's not working yet, on your *computer*:
+
+Troubleshooting
+---------------
+
+If the above steps don't give you working internet connection on your phone the try these steps on your *computer*:
 
    - Turn on IP forwarding: ``echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward``
    - Apply Forwarding iptables Rule: ``sudo iptables -P FORWARD ACCEPT``

--- a/userguide/advanceduse/reverse-tethering.rst
+++ b/userguide/advanceduse/reverse-tethering.rst
@@ -63,6 +63,8 @@ References
 
 - `Ask Ubuntu`_
 - RidgeRun_
+- `Fedora Magazine`_
 
 .. _Ask Ubuntu: https://askubuntu.com/questions/655321/ubuntu-touch-reverse-tethering-and-click-apps-updates
 .. _RidgeRun: https://developer.ridgerun.com/wiki/index.php/How_to_use_USB_device_networking
+.. _Fedora Magazine: https://fedoramagazine.org/internet-connection-sharing-networkmanager/


### PR DESCRIPTION
i'm annoying but i messed with reverse tethering a bit more and it turns out it's actually much simpler

in usb tethering mode we get a network interface using "the shared ipv4 method" on UT and an network interface using "the automatic ipv4 method"

the automatic method is familiar, this is where we automatically get assigned an ip address and dns is setup automatically

the shared method does the following:
- enables IP forwarding for the interface;
- adds firewall rules and enables masquerading;
- starts dnsmasq as a DHCP and DNS server.

in my testing what it doesn't do is `iptables -P FORWARD ACCEPT` 

so for reverse tethering we want the interface on the computer to use the shared method and the interface on the phone to use the automatic method, so i rewrote the steps to reflect that. now we no longer need to fuss with ip addresses, gateways and dns servers

i've yet to confirm if "enable IP forwarding for the interface" makes `echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward` obsolete, it seems that `cat /proc/sys/net/ipv4/ip_forward` already returned `1` for me