### PR TITLE
Clean up gihub issue tracker refs

### DIFF
--- a/about/process/issue-tracking.rst
+++ b/about/process/issue-tracking.rst
@@ -10,7 +10,7 @@ Where are bugs tracked?
 Since quality assurance depends heavily on community effort, issues are
 tracked where users expect them, instead of separated by repository.
 This means issues of almost all distributed components (as with the system-image)
-are tracked in the `Ubuntu Touch tracker <https://github.com/ubports/ubuntu-touch>`__.
+are tracked in the `Ubuntu Touch tracker <https://gitlab.com/ubports/ubuntu-touch>`__.
 An exception to this are click-apps, which can be updated independently through
 the OpenStore.
 

--- a/appdev/index.rst
+++ b/appdev/index.rst
@@ -63,6 +63,6 @@ You can also check out our list of :ref:`preinstalled apps <preinstalledapps>`. 
 Maintainers wanted
 ------------------
 
-All apps love contributions. But some core apps are lacking maintainers. Please check the `list of core apps <https://github.com/ubports/ubuntu-touch/blob/master/CORE_APPS.md>`_ and see if you want to step up as new maintainer for one of our core apps. The maintainer reviews MR's, triages and investigates issue reports and helps to develop the app.
+All apps love contributions. But some core apps are lacking maintainers. Please check the `list of core apps <https://gitlab.com/ubports/ubuntu-touch/-/blob/master/CORE_APPS.md>`_ and see if you want to step up as new maintainer for one of our core apps. The maintainer reviews MR's, triages and investigates issue reports and helps to develop the app.
 
 The best way to start is by making some contributions and let the reviewers know that you are interested. Or join our matrix group at `#ubcd:matrix.org <https://matrix.to/#/#ubcd:matrix.org>`_ and introduce yourself.

--- a/contribute/code.rst
+++ b/contribute/code.rst
@@ -140,7 +140,7 @@ Link changesets to the issue report that they resolve, whether you add a feature
 
 For example:
 
-    Fixes https://github.com/ubports/ubuntu-touch/issues/1
+    Fixes https://gitlab.com/ubports/ubuntu-touch/-/issues/1
 
 How did you test that the change was successful?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/contribute/quality-assurance.rst
+++ b/contribute/quality-assurance.rst
@@ -11,7 +11,7 @@ To test the core functionality of the operating system, we have compiled `a set 
 Confirming bug reports
 ----------------------
 
-Unconfirmed bugreports are labeled **needs confirmation** to enable `global filtering <https://github.com/ubports/ubuntu-touch/issues?q=is%3Aissue+is%3Aopen+label%3A%22needs+confirmation%22>`__. Browse through the list, read the bugreports and try to reproduce the issues that are described. If necessary, add :doc:`missing information or logs, or improve the quality of the report by other means <bugreporting>`. Leave a comment stating your device, channel, build number and whether or not you were able to reproduce the issue.
+Unconfirmed bugreports are labeled **needs confirmation** to enable `global filtering <https://gitlab.com/groups/ubports/-/issues/?sort=created_date&state=opened&or%5Blabel_name%5D%5B%5D=need%20confirmation&or%5Blabel_name%5D%5B%5D=needs%20confirmation&first_page_size=20>`__. Browse through the list, read the bugreports and try to reproduce the issues that are described. If necessary, add :doc:`missing information or logs, or improve the quality of the report by other means <bugreporting>`. Leave a comment stating your device, channel, build number and whether or not you were able to reproduce the issue.
 
 If you have write-access to the repository, you can replace the **needs confirmation** label with **bug** (to mark it confirmed) or **invalid** (if the issue is definitely not reproducible). In that case it should be closed.
 

--- a/userguide/advanceduse/reverse-tethering.rst
+++ b/userguide/advanceduse/reverse-tethering.rst
@@ -1,7 +1,7 @@
 Reverse tethering
 =================
 
-This tutorial explains how you get your Ubuntu Touch device online using a USB cable and a computer with internet access.
+This tutorial explains how you get your Ubuntu Touch device online using a USB cable and a Linux computer with internet access.
 This is useful if there is no available Wi-Fi connection or you don't have a data subscription on your device.
 
 Steps to Set Up Reverse Tethering

--- a/userguide/dailyuse/waydroid.rst
+++ b/userguide/dailyuse/waydroid.rst
@@ -86,4 +86,4 @@ Troubleshooting
 Reporting bugs
 --------------
 
-Please :doc:`report any bugs </contribute/bugreporting>` you come across. Bugs concerning Ubuntu Touch are reported in `the normal Ubuntu Touch tracker <https://github.com/ubports/ubuntu-touch/issues>`_ and issues with Waydroid are reported on `our waydroid issue tracker <https://gitlab.com/ubports/development/core/packaging/waydroid/-/issues>`_. Thank you!
+Please :doc:`report any bugs </contribute/bugreporting>` you come across. Bugs concerning Ubuntu Touch are reported in `the normal Ubuntu Touch tracker <https://gitlab.com/ubports/ubuntu-touch/-/issues>`_ and issues with Waydroid are reported on `our waydroid issue tracker <https://gitlab.com/ubports/development/core/packaging/waydroid/-/issues>`_. Thank you!


### PR DESCRIPTION
looks like there are still references to the old issue tracker in the docs.

i took care of the obvious one in this PR but there seems to be more in the locales folder.

there also seems a few in [the issue tracking page](https://docs.ubports.com/en/latest/about/process/issue-tracking.html) that i fear we'll need rework a lot more than just replace the links, not sure if we want to tackle them all in this pr or how the locales one should be handled